### PR TITLE
handling of zero+empty bid values.

### DIFF
--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -150,7 +150,7 @@ var apiStartCallback = function(hasErrors, errors){
  *
  * @typedef {BidObject} BidObject
  * @property {string} slot - slot name
- * @property {string} value - publisher adserver targeting bid value
+ * @property {string} value - publisher adserver targeting bid value. Default: empty string.
  * @property {array.array.<number, number>} sizes - array of sizes for the slot the bid is for
  * @property {number} sizes.0 width
  * @property {number} sizes.1 height

--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -166,7 +166,8 @@ var bidObject = {
 };
 bidObject.optional = {
   targeting: true,
-  label: true
+  label: true,
+  value: true
 };
 
 /**

--- a/src/mediator/auctionmediator.js
+++ b/src/mediator/auctionmediator.js
@@ -286,13 +286,13 @@ AuctionMediator.prototype.buildTargeting_ = function() {
     for (var k = 0; k < slotBids.length; k++) {
       var bid = slotBids[k];
       t.bids.push({
-        value: bid.value,
+        value: bid.value || '',
         provider: bid.provider,
         id: bid.id,
         targeting: bid.targeting
       });
       var bidKey = this.getBidKey(bid);
-      t.targeting[bidKey] = t.targeting[bidKey] || bid.value;
+      t.targeting[bidKey] = t.targeting[bidKey] || (bid.value || '');
       this.mergeKeys(t.targeting, bid.targeting);
     }
 
@@ -361,6 +361,8 @@ AuctionMediator.prototype.addSlot = function(slotConfig) {
   if (slot) {
     this.slots.push(slot);
     this.slotMap[slot.name] = slot;
+  } else {
+    Event.publish(Event.EVENT_TYPE.WARN, 'Invalid slot object: ' + JSON.stringify(slotConfig || {}));
   }
   return this;
 };

--- a/src/mediator/bidmediator.js
+++ b/src/mediator/bidmediator.js
@@ -88,8 +88,12 @@ BidMediator.prototype.getBids_ = function(provider, slots) {
  */
 BidMediator.prototype.pushBid = function(bid, providerName) {
   var b = Bid.fromObject(bid);
-  b.provider = providerName;
-  Event.publish(Event.EVENT_TYPE.BID_PUSH_NEXT, b);
+  if (b) {
+    b.provider = providerName;
+    Event.publish(Event.EVENT_TYPE.BID_PUSH_NEXT, b);
+  } else {
+    Event.publish(Event.EVENT_TYPE.WARN, 'Invalid bid object: ' + JSON.stringify(bid || {}));
+  }
 };
 
 /**

--- a/src/model/bid.js
+++ b/src/model/bid.js
@@ -17,7 +17,7 @@ var BidObject = require('../interfaces').BidObject;
  *
  * @class
  * @param {string} slot the slot name
- * @param {string|number} value the bid value
+ * @param {string|number} value the bid value. Default: empty string.
  * @param {Array.<number, number>} sizes the dimension sizes of the slot bid
  * @memberof pubfood#model
  */

--- a/src/util.js
+++ b/src/util.js
@@ -143,15 +143,21 @@ var util = {
 
       var isOpt = !!type.optional &&!!type.optional[k],
         hasProp = obj.hasOwnProperty(k),
-        isSet = !!obj[k],
-        isModel = !obj['init'];
+        valType = this.asType(obj[k]),
+        isModel = !obj['init'],
+        isSet = true;
+
+      if (valType === 'null' || valType === 'undefined'
+          || (valType === 'number' && !isFinite(obj[k]))
+          || (valType === 'string' && obj[k] === '')
+         ) isSet = false;
 
       if (!isOpt && (!hasProp || !isSet)) ++err;
 
       if (isSet && isModel &&
         (util.isArray(obj[k]) && obj[k].length === 0)) ++err;
 
-      if (isSet && !isModel &&
+      if (isSet && !isModel && // model object Bid+Slot can have mixed types
         (util.asType(obj[k]) !== util.asType(type[k]))) ++err;
 
       if (err > 0) break;

--- a/test/api-callbacks.js
+++ b/test/api-callbacks.js
@@ -34,10 +34,13 @@ if (!global.document) {
 var assert = require('chai').assert;
 var expect = require('chai').expect;
 var pubfood = require('../src/pubfood');
+var Event = require('../src/event');
 var auctionExample = require('./fixture/auctionexample1');
 
 describe('Api Callbacks - Tests', function() {
   it('should call all the callbacks', function(done) {
+
+    Event.removeAllListeners();
 
     //
     var bidProviderDoneCalled = {

--- a/test/api-callbacks.js
+++ b/test/api-callbacks.js
@@ -38,9 +38,12 @@ var Event = require('../src/event');
 var auctionExample = require('./fixture/auctionexample1');
 
 describe('Api Callbacks - Tests', function() {
-  it('should call all the callbacks', function(done) {
 
+  beforeEach(function() {
     Event.removeAllListeners();
+  });
+
+  it('should call all the callbacks', function(done) {
 
     //
     var bidProviderDoneCalled = {

--- a/test/fixture/auctionconfig1.js
+++ b/test/fixture/auctionconfig1.js
@@ -173,6 +173,7 @@ var pubfoodContrib = {
               },
               label: 'price'
             };
+            delete bidObject.value; // pubfood core should not fail with missing value property
             pushBid(bidObject);
           }
 

--- a/test/fixture/bid1.js
+++ b/test/fixture/bid1.js
@@ -42,11 +42,6 @@ module.exports = {
   ],
   invalid: [
     {
-      sizes: [300, 250],
-      slot: '/this/is/a/slot',
-      value: null
-    },
-    {
       targeting: {
         yes: 'yes',
         no: 'no'

--- a/test/mediator/auctionmediator.js
+++ b/test/mediator/auctionmediator.js
@@ -185,8 +185,8 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
   });
 
   it('should handle push next', function() {
-    delete Event._events;
-    Event._events = {};
+    Event.removeAllListeners();
+
     var m = new AuctionMediator();
 
     m.addSlot({

--- a/test/mediator/auctionmediator.js
+++ b/test/mediator/auctionmediator.js
@@ -12,6 +12,11 @@ var logger = require('../../src/logger');
 var Bid = require('../../src/model/bid');
 /** @todo generalize fixture config to improve readability of tests */
 describe('Pubfood AuctionMediator', function testPubfoodMediator() {
+
+  beforeEach(function() {
+    Event.removeAllListeners();
+  });
+
   it('should set a timeout', function() {
     var m = new AuctionMediator();
     m.timeout(1000);
@@ -185,7 +190,6 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
   });
 
   it('should handle push next', function() {
-    Event.removeAllListeners();
 
     var m = new AuctionMediator();
 

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -105,31 +105,50 @@ describe('Util - Tests', function () {
   });
 
   it('should validate object properties', function() {
-    var b = {};
-    assert.isFalse(util.validate(BidObject, b), 'empty object should not be valid');
 
-    b.slot = '';
-    assert.isFalse(util.validate(BidObject, b), 'object with required string property empty should not be valid');
+    assert.isFalse(util.validate(BidObject, {}), 'empty object should not be valid');
 
-    b.slot = 0;
-    assert.isFalse(util.validate(BidObject, b), 'object with required string property with numeric should not be valid');
+    var BID_REQUIRED_EMPTY_STR = {
+      slot: '',
+      sizes: [[728,90]],
+      value: 33
+    };
+    assert.isFalse(util.validate(BidObject, BID_REQUIRED_EMPTY_STR), 'object with required string property empty should not be valid');
 
-    b.slot = 's1';
-    b.sizes = [];
-    b.value = 33;
-    assert.isFalse(util.validate(BidObject, b), 'object with empty required array property should not be valid');
+    var BID_EMPTY_SIZES = {
+      slot: 's1',
+      sizes: [],
+      value: 33
+    };
+    assert.isFalse(util.validate(BidObject, BID_EMPTY_SIZES), 'object with empty required array property should not be valid');
 
-    b.sizes.push('anything');
-    assert.isTrue(util.validate(BidObject, b), 'object with required properties set should be valid');
+    var BID_PROPS_SET = {
+      slot: 's1',
+      sizes: [[300, 600]],
+      value: ''
+    };
+    assert.isTrue(util.validate(BidObject, BID_PROPS_SET), 'object with required properties set should be valid');
 
-    b.value = 0;
-    assert.isTrue(util.validate(BidObject, b), 'object with optional property numeric falsy (zero) should be valid');
+    var BID_VALUE_ZERO = {
+      slot: 's1',
+      sizes: [[300, 250]],
+      value: 0
+    };
+    assert.isTrue(util.validate(BidObject, BID_VALUE_ZERO), 'object with optional property numeric falsy (zero) should be valid');
 
-    b.value = '';
-    assert.isTrue(util.validate(BidObject, b), 'object with optional property falsy set should be valid');
+    var BID_VALUE_EMPTY_STR = {
+      slot: 's1',
+      sizes: [[300, 250]],
+      value: ''
+    };
+    assert.isTrue(util.validate(BidObject, BID_VALUE_EMPTY_STR), 'object with optional property falsy set should be valid');
 
-    b.sizes = {};
-    assert.isTrue(util.validate(BidObject, b), 'object with array property with object set should not be valid');
+    var BID_SIZES_NOT_ARRAY = {
+      slot: 's1',
+      sizes: {},
+      value: ''
+    };
+    assert.isTrue(util.validate(BidObject, BID_SIZES_NOT_ARRAY), 'object with array property with object set should not be valid');
 
   });
 });

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -5,6 +5,7 @@
 
 var assert = require('chai').assert;
 var util = require('../../src/util');
+var BidObject = require('../../src/interfaces').BidObject;
 
 /*eslint no-unused-vars: 0*/
 /*eslint no-undef: 0*/
@@ -101,5 +102,34 @@ describe('Util - Tests', function () {
 
     target = util.mergeToObject(target, source);
     assert.isTrue(target.prefix === 'bar', 'source should overwrite target property');
+  });
+
+  it('should validate object properties', function() {
+    var b = {};
+    assert.isFalse(util.validate(BidObject, b), 'empty object should not be valid');
+
+    b.slot = '';
+    assert.isFalse(util.validate(BidObject, b), 'object with required string property empty should not be valid');
+
+    b.slot = 0;
+    assert.isFalse(util.validate(BidObject, b), 'object with required string property with numeric should not be valid');
+
+    b.slot = 's1';
+    b.sizes = [];
+    b.value = 33;
+    assert.isFalse(util.validate(BidObject, b), 'object with empty required array property should not be valid');
+
+    b.sizes.push('anything');
+    assert.isTrue(util.validate(BidObject, b), 'object with required properties set should be valid');
+
+    b.value = 0;
+    assert.isTrue(util.validate(BidObject, b), 'object with optional property numeric falsy (zero) should be valid');
+
+    b.value = '';
+    assert.isTrue(util.validate(BidObject, b), 'object with optional property falsy set should be valid');
+
+    b.sizes = {};
+    assert.isTrue(util.validate(BidObject, b), 'object with array property with object set should not be valid');
+
   });
 });


### PR DESCRIPTION
Resolves #1

Bids with a *falsy* **`value`** property were incorrectly invalidated.

The warning mentioned in issue #1 was due to the invalid bid circumventing the bid provider `done()` callback:
`"Warning: The bid done callback for "yieldbot" hasn't been called within the allotted time (2sec)”`

Added further handling for this case and also additional logging for Slot and Bid fromObject to **WARN** on invalid objects; which will be minimized now.