### PR TITLE
feature: optional refresh properties on provider delegate objects

### DIFF
--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -15,7 +15,7 @@
  * @property {function} init Auction provider delegate initial auction request.<br>Called at startup.
  * @property {array.<object>} init.targeting - array of {@link SlotTargetingObject}|{@link PageTargetingObject}
  * @property {auctionDoneCallback} init.done Callback to execute on done
- * @property {function} refresh Auction provider delegate refresh auction request.<br>Called at startup.
+ * @property {function} [refresh] Auction provider delegate refresh auction request.<br>Called at startup.
  * @property {array.<object>} refresh.targeting - array of {@link SlotTargetingObject}|{@link PageTargetingObject}
  * @property {auctionDoneCallback} refresh.done Callback to execute on done
  * @property {function} [trigger] Auction provider delegate function to trigger the auction. Default: [pubfood.timeout]{@link pubfood#timeout}
@@ -28,7 +28,7 @@ var auctionDelegate = {
   refresh: function(targeting, done) {}
 };
 auctionDelegate.optional = {
-
+  refresh: true
 };
 
 /**
@@ -41,7 +41,7 @@ auctionDelegate.optional = {
  * @property {Slot[]} init.slots slots to bid on
  * @property {pushBidCallback} init.pushBid Callback to execute on next bid available
  * @property {bidDoneCallback} init.done Callback to execute on done
- * @property {function} refresh Refresh bids for [BidProvider.refresh]{@link pubfood#provider.BidProvider#refresh} delegate.
+ * @property {function} [refresh] Refresh bids for [BidProvider.refresh]{@link pubfood#provider.BidProvider#refresh} delegate.
  * @property {Slot[]} refresh.slots slots to bid on
  * @property {pushBidCallback} refresh.pushBid Callback to execute on next bid available
  * @property {bidDoneCallback} refresh.done Callback to execute on done
@@ -57,6 +57,7 @@ var bidDelegate = {
   }
 };
 bidDelegate.optional = {
+  refresh: true
 };
 
 /**

--- a/src/provider/auctionprovider.js
+++ b/src/provider/auctionprovider.js
@@ -97,7 +97,12 @@ AuctionProvider.prototype.init = function(targeting, done) {
  * @param {auctionDoneCallback} done a callback to execute on init complete
  */
 AuctionProvider.prototype.refresh = function(targeting, done) {
-  this.auctionDelegate.refresh(targeting, done);
+  var refresh = (this.auctionDelegate && this.auctionDelegate.refresh) || null;
+  if (!refresh) {
+    Event.publish(Event.EVENT_TYPE.WARN, 'AuctionProvider.auctionDelegate.refresh not defined.');
+    return;
+  }
+  refresh(targeting, done);
 };
 
 module.exports = AuctionProvider;

--- a/src/provider/bidprovider.js
+++ b/src/provider/bidprovider.js
@@ -96,7 +96,12 @@ BidProvider.prototype.init = function(slots, pushBid, done) {
  * @param {bidDoneCallback} done - a callback to execute on init complete
  */
 BidProvider.prototype.refresh = function(slots, pushBid, done) {
-  this.bidDelegate.refresh(slots, pushBid, done);
+  var refresh = (this.bidDelegate && this.bidDelegate.refresh) || null;
+  if (!refresh) {
+    Event.publish(Event.EVENT_TYPE.WARN, 'BidProvider.bidDelegate.refresh not defined.');
+    return;
+  }
+  refresh(slots, pushBid, done);
 };
 
 module.exports = BidProvider;

--- a/test/fixture/auctionprovider1.js
+++ b/test/fixture/auctionprovider1.js
@@ -21,6 +21,17 @@ module.exports = {
           done();
         }, 100);
       }
+    },
+    {
+      name: 'provider1',
+      libUri: '../test/fixture/lib.js',
+      init: function(slots, bids, done) {
+      },
+      trigger: function(done) {
+        setTimeout(function() {
+          done();
+        }, 100);
+      }
     }
   ],
   invalid: [
@@ -60,7 +71,6 @@ module.exports = {
       }
     },
     {
-      name: 'provider4',
       libUri: '../test/fixture/lib.js',
       init: function(slots, bids, done) {
       },

--- a/test/fixture/bidprovider1.js
+++ b/test/fixture/bidprovider1.js
@@ -16,6 +16,12 @@ module.exports = {
       },
       refresh: function(slots, options, pushBid, done) {
       }
+    },
+    {
+      name: 'bidder1',
+      libUri: '//localhost/cdn/bidder1.js',
+      init: function(slots, options, pushBid, done) {
+      }
     }
   ],
   invalid: [
@@ -24,7 +30,6 @@ module.exports = {
     },
     {
       name: 'bidder1',
-      libUri: '//localhost/cdn/bidder1.js',
       init: function(slots, options, pushBid, done) {
       }
     },

--- a/test/provider/auctionprovider.js
+++ b/test/provider/auctionprovider.js
@@ -30,4 +30,34 @@ describe('Pubfood AuctionProvider', function() {
       assert.match(log.args[1].msg, /^Warn: invalid auction delegate/, 'was not a validation error on delegate');
     }
   });
+
+  it('should not reference optional refresh delegate if not defined', function() {
+
+    var AUCTION_PROVIDER_NO_REFRESH = {
+      name: 'no-refresh',
+      libUri: 'the Uri',
+      init: function() {}
+    };
+
+    var ap = AuctionProvider.withDelegate(AUCTION_PROVIDER_NO_REFRESH);
+    assert.isDefined(ap.refresh);
+    assert.isDefined(ap.auctionDelegate);
+
+    ap.refresh();
+    var log = logger.history[logger.history.length - 1];
+    assert.match(log.args[1], /^AuctionProvider.auctionDelegate.refresh/, 'should get auctionDelegate warning');
+
+    var AUCTION_PROVIDER_WITH_REFRESH = {
+      name: 'no-refresh',
+      libUri: 'the Uri',
+      init: function() {},
+      refresh: function() { testRefresh = true; }
+    };
+
+    var testRefresh = false;
+    var ap2 = AuctionProvider.withDelegate(AUCTION_PROVIDER_WITH_REFRESH);
+    ap2.refresh();
+    assert.isTrue(testRefresh, 'refresh delegate not called');
+  });
+
 });

--- a/test/provider/bidprovider.js
+++ b/test/provider/bidprovider.js
@@ -30,4 +30,33 @@ describe('Pubfood BidProvider', function() {
       assert.match(log.args[1].msg, /^Warn: invalid bidder delegate/, 'was not a validation error on delegate');
     }
   });
+
+  it('should not reference optional refresh delegate if not defined', function() {
+
+    var BID_PROVIDER_NO_REFRESH = {
+      name: 'no-refresh',
+      libUri: 'the Uri',
+      init: function(slots, pushBid, done) {}
+    };
+
+    var bp = BidProvider.withDelegate(BID_PROVIDER_NO_REFRESH);
+    assert.isDefined(bp.refresh);
+    assert.isDefined(bp.bidDelegate);
+
+    bp.refresh();
+    var log = logger.history[logger.history.length - 1];
+    assert.match(log.args[1], /^BidProvider.bidDelegate.refresh/, 'should get bidDelegate warning');
+
+    var BID_PROVIDER_WITH_REFRESH = {
+      name: 'no-refresh',
+      libUri: 'the Uri',
+      init: function() {},
+      refresh: function() { testRefresh = true; }
+    };
+
+    var testRefresh = false;
+    var bp2 = BidProvider.withDelegate(BID_PROVIDER_WITH_REFRESH);
+    bp2.refresh();
+    assert.isTrue(testRefresh, 'refresh delegate not called');
+  });
 });


### PR DESCRIPTION
Make the `refresh` property on bid and auction providers optional for calls:
- `pubfood.addBidProvider()`
- `pubfood.setAuctionProvider()`

If a bid or auction provider delegate object does not have `refresh` defined a warning will be logged. e.g.
`{"ts":1447448309038,"type":"WARN","eventContext":"pubfood","data":"BidProvider.bidDelegate.refresh not defined."}`