### PR TITLE
fix(timeout): bidder completion status

### DIFF
--- a/test/api-callbacks.js
+++ b/test/api-callbacks.js
@@ -39,8 +39,18 @@ var auctionExample = require('./fixture/auctionexample1');
 
 describe('Api Callbacks - Tests', function() {
 
-  beforeEach(function() {
+  function clearEvents() {
     Event.removeAllListeners();
+    Event.observeImmediate_ = null;
+    Event.observeImmediate_ = {};
+  }
+
+  beforeEach(function() {
+    clearEvents();
+  });
+
+  afterEach(function() {
+    clearEvents();
   });
 
   it('should call all the callbacks', function(done) {

--- a/test/index.html
+++ b/test/index.html
@@ -102,6 +102,8 @@
           };
           pf.setAuctionTrigger(trigger);
 
+          // alternatively for timeout, use pubfood.timeout(millis); e.g.
+          // pf.timeout(6000);
           function augmentBids(bids, params) {
             for (var i = 0; i < bids.length; i++) {
               bids[i]['targeting'].code = (0 | Math.random() * 36).toString(36);

--- a/test/mediator/auctionmediator.js
+++ b/test/mediator/auctionmediator.js
@@ -87,6 +87,9 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
     bidderSlots = m1.getBidderSlots();
 
     assert.isTrue(bidderSlots.length === 1, 'm1 should have one BidProvider for requests');
+    assert.isUndefined(m1.bidStatus['b1'], 'm1 should not track BidProvider b1');
+    assert.isUndefined(m1.bidStatus['b3'], 'm1 should not track BidProvider b3');
+
     assert.isDefined(m1.bidStatus['b2'], 'm1 should track BidProvider b2');
     assert.isFalse(m1.bidStatus['b2'], 'BidProvider b2 should not have bid status complete');
 
@@ -221,13 +224,13 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
     Event.publish('BID_COMPLETE', 'b1');
 
     Event.on(Event.EVENT_TYPE.BID_COMPLETE, function(evt) {
-      assert.isDefined(evt.data === 'b1');
+      assert.isTrue(evt.data === 'b1');
     });
 
     m.checkBids_('b1');
 
     Event.on(Event.EVENT_TYPE.AUCTION_GO, function(evt) {
-      assert.isDefined(evt.data === 'p1');
+      assert.isTrue(evt.data === 'p1');
     });
   });
 


### PR DESCRIPTION
Fixes #9 

Only those `BidProvider.name` identifiers allocated to a `Slot` in the auction are checked for having made their `done()` callback.

@solenoid can you take a look over this commit? Right now, I think you are the closest to the event and timing.