### PR TITLE
fix(event): flush immediate observers

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -17,10 +17,17 @@ var EventEmitter = require('eventemitter3');
  * @property {string} type The event type
  * @property {string} provider The type of provider. Defaults to <i>pubfood</i>
  * @property {object|string} data Data structure for each event type
- * @return {pubfood.PubfoodEvent}
+ * @return {PubfoodEvent}
+ * @extends EventEmitter
+ * @see https://github.com/primus/eventemitter3
  */
 function PubfoodEvent() {
   this.auction_ = 1;
+  /**
+   * Map of emitted events without registered handlers.
+   *
+   * @private
+   */
   this.observeImmediate_ = {};
   // PubfoodEvent constructor
 }
@@ -181,60 +188,25 @@ PubfoodEvent.prototype.publish = function(eventType, data, eventContext) {
   });
 };
 
-/**
- * Emit an event to all registered event listeners.
- * @function emit
- * @memberof pubfood.PubfoodEvent
- * @see https://github.com/primus/eventemitter3
- * @private
- */
-
-/**
- * Register a new EventListener for the given event.
- * @function on
- * @memberof pubfood.PubfoodEvent
- * @see https://github.com/primus/eventemitter3
-  */
-
-/**
- * Add an EventListener that's only called once.
- * @function once
- * @memberof pubfood.PubfoodEvent
- * @see https://github.com/primus/eventemitter3
- * @private
- */
-
-/**
- * Remove event listeners.
- * @function removeListener
- * @memberof pubfood.PubfoodEvent
- * @see https://github.com/primus/eventemitter3
- * @private
- */
-
-/**
- * Remove all listeners or only the listeners for the specified event.
- * @function removeAllListeners
- * @memberof pubfood.PubfoodEvent
- * @see https://github.com/primus/eventemitter3
- * @private
- */
-
-/**
- * Return a list of assigned event listeners.
- * @function listeners
- * @memberof pubfood.PubfoodEvent
- * @see https://github.com/primus/eventemitter3
- * @private
- */
-
 util.extends(PubfoodEvent, EventEmitter);
 
+/**
+ * Emit event, but keep events without a registered listener.
+ *
+ * Emitted events without a listener are stored as events to
+ * be immediately observed by listeners; if a listener is added
+ * subsequently.
+ *
+ * @see https://github.com/primus/eventemitter3
+ *
+ * @param {string} event the event type
+ * @return {boolean} - true if the event was emitted. false otherwise.
+ * @extends EventEmitter
+ * @private
+ */
 PubfoodEvent.prototype.emit = function(event) {
   var ret = EventEmitter.prototype.emit.apply(this, arguments);
 
-  // Always allow AUCTION_POST_RUN events to execute immediately
-  // after the emitted event
   if (!ret || this.EVENT_TYPE.AUCTION_POST_RUN === event) {
     ret = true;
     this.observeImmediate_[event] = this.observeImmediate_[event] || [];
@@ -243,6 +215,20 @@ PubfoodEvent.prototype.emit = function(event) {
   return ret;
 };
 
+/**
+ * Register an event listener.
+ *
+ * Registeres a listener for the event type. If events for the specified type
+ * have already been emitted, the registered handler function is invoked immediately.
+ *
+ * @see https://github.com/primus/eventemitter3
+ *
+ * @param {string} event the event type
+ * @param {function} fn the event handler function
+ * @return {PubfoodEvent} - this
+ * @extends EventEmitter
+ * @private
+ */
 PubfoodEvent.prototype.on = function(event, fn) {
   var emitted = this.observeImmediate_[event] || null;
   if (emitted) {
@@ -254,6 +240,19 @@ PubfoodEvent.prototype.on = function(event, fn) {
   return EventEmitter.prototype.on.apply(this, arguments);
 };
 
+/**
+ * Remove all event listeners.
+ *
+ * Removes both extended EventEmitter listeners and internal
+ * {@link pubfood#PubfoodEvent.emit} immediate listeners.
+ *
+ * @see https://github.com/primus/eventemitter3
+ *
+ * @param {string} event the event type
+ * @return {PubfoodEvent} - this
+ * @extends EventEmitter
+ * @private
+ */
 PubfoodEvent.prototype.removeAllListeners = function(event) {
   EventEmitter.prototype.removeAllListeners.call(this, event);
 

--- a/src/event.js
+++ b/src/event.js
@@ -248,13 +248,12 @@ PubfoodEvent.prototype.on = function(event, fn) {
  *
  * @see https://github.com/primus/eventemitter3
  *
- * @param {string} event the event type
  * @return {PubfoodEvent} - this
  * @extends EventEmitter
  * @private
  */
-PubfoodEvent.prototype.removeAllListeners = function(event) {
-  EventEmitter.prototype.removeAllListeners.call(this, event);
+PubfoodEvent.prototype.removeAllListeners = function() {
+  EventEmitter.prototype.removeAllListeners.call(this);
 
   this.observeImmediate_ = {};
 

--- a/src/event.js
+++ b/src/event.js
@@ -254,4 +254,12 @@ PubfoodEvent.prototype.on = function(event, fn) {
   return EventEmitter.prototype.on.apply(this, arguments);
 };
 
+PubfoodEvent.prototype.removeAllListeners = function(event) {
+  EventEmitter.prototype.removeAllListeners.call(this, event);
+
+  this.observeImmediate_ = {};
+
+  return this;
+};
+
 module.exports = new PubfoodEvent();

--- a/test/api-callbacks.js
+++ b/test/api-callbacks.js
@@ -39,18 +39,12 @@ var auctionExample = require('./fixture/auctionexample1');
 
 describe('Api Callbacks - Tests', function() {
 
-  function clearEvents() {
-    Event.removeAllListeners();
-    Event.observeImmediate_ = null;
-    Event.observeImmediate_ = {};
-  }
-
   beforeEach(function() {
-    clearEvents();
+    Event.removeAllListeners();
   });
 
   afterEach(function() {
-    clearEvents();
+    Event.removeAllListeners();
   });
 
   it('should call all the callbacks', function(done) {

--- a/test/api-callbacks.js
+++ b/test/api-callbacks.js
@@ -43,17 +43,12 @@ describe('Api Callbacks - Tests', function() {
     Event.removeAllListeners();
   });
 
-  afterEach(function() {
-    Event.removeAllListeners();
-  });
-
   it('should call all the callbacks', function(done) {
 
-    //
     var bidProviderDoneCalled = {
-      //yieldbot: false,
-      //bidderFast: false,
-      //bidderSlow: false
+      yieldbot: false,
+      bidderFast: false,
+      bidderSlow: false
     };
 
     var pf = new pubfood({

--- a/test/event/index.js
+++ b/test/event/index.js
@@ -30,6 +30,35 @@ describe('Event - Tests', function () {
 
     done();
   });
+  it('should remove all listeners when event argument supplied', function(done) {
+    var spy = sinon.spy();
+
+    Event.on('hello', spy); // hello listener 1
+    Event.emit('hello', 1); // call-1
+    sinon.assert.calledOnce(spy, 'listener should be called once');
+
+    Event.removeAllListeners('hello');
+
+    Event.on('hello', spy); // hello listener 1
+    Event.emit('hello', 2); // call-2
+    sinon.assert.calledTwice(spy, 'listener should be called twice');
+
+    Event.removeAllListeners(0);
+
+    // Invert on/emit calls for immediate observer removal
+    Event.emit('hello', 3); // call-3
+    Event.on('hello', spy); // hello listener 1
+    sinon.assert.calledThrice(spy, 'listener should be called thrice');
+
+    var foo;
+    Event.removeAllListeners(foo);
+
+    Event.emit('hello', 3); // call-4
+    Event.on('hello', spy); // hello listener 1
+    sinon.assert.called(spy, 4, 'listener should be called four times');
+
+    done();
+  });
   it('should remove immediate listeners', function(done) {
     var spy = sinon.spy();
 

--- a/test/event/index.js
+++ b/test/event/index.js
@@ -5,6 +5,7 @@
 
 var sinon = require('sinon');
 var Event = require('../../src/event');
+var assert = require('chai').assert;
 
 /*eslint no-undef: 0*/
 describe('Event - Tests', function () {
@@ -13,17 +14,39 @@ describe('Event - Tests', function () {
   });
   it('should remove all listeners', function(done) {
     var spy = sinon.spy();
-    Event.on('hello', spy);
-    Event.emit('hello', 1);
-    sinon.assert.called(spy, 'listener not called');
+
+    Event.on('hello', spy); // hello listener 1
+    Event.emit('hello', 1); // call-1
+    sinon.assert.calledOnce(spy, 'listener should be called once');
 
     Event.removeAllListeners();
-    Event.emit('hello', 1);
-    sinon.assert.calledOnce(spy, 'listener called more than once');
 
-    Event.on('hello', spy);
-    Event.emit('hello', 1);
-    sinon.assert.calledTwice(spy, 'listener not called twice');
+    Event.on('hello', spy); // hello listener 1
+    Event.emit('hello', 2); // call-2
+    sinon.assert.calledTwice(spy, 'listener should be called twice');
+
+    Event.on('hello', spy); // hello listener 2
+    Event.emit('hello', 3); // call-3, call-4
+    sinon.assert.callCount(spy, 4, 'listener should be called four times');
+
+    done();
+  });
+  it('should remove immediate listeners', function(done) {
+    var spy = sinon.spy();
+
+    Event.emit('hello'); // call-1
+    Event.on('hello', spy); // hello listener 1
+    sinon.assert.calledOnce(spy, 'listener should be called once');
+
+    Event.removeAllListeners();
+
+    Event.emit('hello'); // call-2
+    Event.on('hello', spy); // hello listener 1
+    sinon.assert.calledTwice(spy, 'listener should be called twice');
+
+    Event.emit('hello'); // call-3, call-4
+    Event.on('hello', spy); // hello listener 2
+    sinon.assert.callCount(spy, 4, 'listener should be called four times');
 
     done();
   });

--- a/test/event/index.js
+++ b/test/event/index.js
@@ -5,7 +5,6 @@
 
 var sinon = require('sinon');
 var Event = require('../../src/event');
-var assert = require('chai').assert;
 
 /*eslint no-undef: 0*/
 describe('Event - Tests', function () {

--- a/test/event/index.js
+++ b/test/event/index.js
@@ -10,8 +10,22 @@ var Event = require('../../src/event');
 describe('Event - Tests', function () {
   beforeEach(function() {
     Event.removeAllListeners();
-    // TODO consider if this should be a formal API instead
-    Event.observeImmediate_ = {};
+  });
+  it('should remove all listeners', function(done) {
+    var spy = sinon.spy();
+    Event.on('hello', spy);
+    Event.emit('hello', 1);
+    sinon.assert.called(spy, 'listener not called');
+
+    Event.removeAllListeners();
+    Event.emit('hello', 1);
+    sinon.assert.calledOnce(spy, 'listener called more than once');
+
+    Event.on('hello', spy);
+    Event.emit('hello', 1);
+    sinon.assert.calledTwice(spy, 'listener not called twice');
+
+    done();
   });
   it('should invoke the done callback', function(done) {
     Event.on('hello', done);

--- a/test/mediator/auctionmediator.js
+++ b/test/mediator/auctionmediator.js
@@ -13,15 +13,9 @@ var Bid = require('../../src/model/bid');
 /** @todo generalize fixture config to improve readability of tests */
 describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
-  function clearEvents() {
-    Event.removeAllListeners();
-    Event.observeImmediate_ = null;
-    Event.observeImmediate_ = {};
-  }
-
   var TEST_MEDIATOR;
   beforeEach(function() {
-    clearEvents();
+    Event.removeAllListeners();
 
     TEST_MEDIATOR = null;
     TEST_MEDIATOR = new AuctionMediator();
@@ -67,7 +61,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
   });
 
   afterEach(function() {
-    clearEvents();
+    Event.removeAllListeners();
   });
 
   it('should set a timeout', function() {

--- a/test/mediator/auctionmediator.js
+++ b/test/mediator/auctionmediator.js
@@ -60,10 +60,6 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
   });
 
-  afterEach(function() {
-    Event.removeAllListeners();
-  });
-
   it('should set a timeout', function() {
     var m = new AuctionMediator();
     m.timeout(1000);


### PR DESCRIPTION
closes #10 

Mainly an issue for asynchronous tests. The _so called_ "immediate observers" aka `PubfoodEvent.observeImmediate_` event listeners are not removed from the `PubfoodEvent` singleton.

In a single page view this would not be an issue, but it is possible that on a pubfood `refresh` this could produce undesired event listener invocation and difficult to debug issues.