### PR TITLE
doc(api): PubfoodObject internal

### DIFF
--- a/src/model/slot.js
+++ b/src/model/slot.js
@@ -14,7 +14,7 @@ var slotConfig = require('../interfaces').SlotConfig;
  * @class
  * @param {string} name the slot name
  * @param {string} elementId target DOM element id for the slot
- * @augments pubfood.PubfoodObject
+ * @augments PubfoodObject
  * @memberof pubfood#model
  */
 function Slot(name, elementId) {

--- a/src/provider/auctionprovider.js
+++ b/src/provider/auctionprovider.js
@@ -16,7 +16,7 @@ var PubfoodObject = require('../pubfoodobject');
  * @property {string} name the name of the provider
  * @memberof pubfood#provider
  * @param {AuctionDelegate} auctionDelegate the delegate object that implements [libUri()]{@link pubfood#provider.AuctionProvider#libUri}, [init()]{@link pubfood#provider.AuctionProvider#init} and [refresh()]{@link pubfood#provider.AuctionProvider#refresh}
- * @augments pubfood.PubfoodObject
+ * @augments PubfoodObject
  */
 function AuctionProvider(auctionDelegate) {
   if (this.init_) {

--- a/src/provider/bidprovider.js
+++ b/src/provider/bidprovider.js
@@ -15,7 +15,7 @@ var PubfoodObject = require('../pubfoodobject');
  * @class
  * @param {BidDelegate} delegate the delegate object that implements [libUri()]{@link pubfood#provider.BidProvider#libUri}, [init()]{@link pubfood#provider.BidProvider#init} and [refresh()]{@link pubfood#provider.BidProvider#refresh}
  * @property {string} name the name of the provider
- * @augments pubfood.PubfoodObject
+ * @augments PubfoodObject
  * @memberof pubfood#provider
  */
 function BidProvider(bidDelegate) {

--- a/src/pubfoodobject.js
+++ b/src/pubfoodobject.js
@@ -10,7 +10,6 @@ var util = require('./util');
  * PubfoodObject is a base type for pubfood types.
  *
  * @class
- * @memberof pubfood
  */
 function PubfoodObject() {
   this.id = util.newId();


### PR DESCRIPTION
Make `PubfoodObject` able to be `@link`'d or be referenced by type, but need not list in the _**Classes**_ nav menu on:
- http://pubfood.org/api-reference#anchor-section-heading-1