### PR TITLE
refactor: mark targeting object type property for deprecation

### DIFF
--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -218,7 +218,8 @@ var slotConfig = {
  * @typedef {TargetingObject} TargetingObject
  *
  * Key value targeting for a specific slot or the page.
- *
+ * @property {string} [type] the targeting level [slot|page]
+ * @deprecated Property, <code>TargetingObject.type [slot|page]</code>.<br> Use the existence of "<em><code>TargetingObject.name</code></em>" to detect targeting is slot-level
  * @property {string} [name] the [Slot.name]{@link pubfood#model.Slot#name}
  * @property {string} [id] if targeting object is for a slot, the generated identifier of the slot
  * @property {string} [elementId] the target DOM element id

--- a/src/mediator/auctionmediator.js
+++ b/src/mediator/auctionmediator.js
@@ -376,6 +376,7 @@ AuctionMediator.prototype.buildTargeting_ = function(auctionIdx) {
     tgtObject.id = slot.id;
     tgtObject.elementId = slot.elementId || '';
     tgtObject.sizes = slot.sizes;
+    tgtObject.type = 'slot';
 
     bidSet = bidMap[slot.name] || [];
     for (var j = 0; j < bidSet.length; j++) {
@@ -413,6 +414,7 @@ AuctionMediator.prototype.buildTargeting_ = function(auctionIdx) {
     this.mergeKeys(pgTgtObject.targeting, bid.targeting);
   }
   if (pgTgtObject.bids.length > 0) {
+    pgTgtObject.type = 'page';
     auctionTargeting.push(pgTgtObject);
   }
   return auctionTargeting;

--- a/src/model/bid.js
+++ b/src/model/bid.js
@@ -25,7 +25,7 @@ function Bid(value) {
   this.value = value || 0;
   /** @property {string} type bid value type derived from {@link util.asType}  */
   this.type = util.asType(this.value);
-  /** @property {string} [label] optional label for adserver key targeting for bid value e.g. <label>=2.00 */
+  /** @property {string} [label] optional label for adserver key targeting for bid value e.g. <code>label=2.00</code> */
   this.label;
   /** @property {string} [provider] the bid provider name */
   this.provider;

--- a/test/mediator/auctionmediator.js
+++ b/test/mediator/auctionmediator.js
@@ -701,6 +701,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
       var auctionTargeting = TEST_MEDIATOR.buildTargeting_(auctionIdx);
       assert.equal(auctionTargeting.length, 1, 'should have one targeting object');
       assert.equal(auctionTargeting[0].name, bid.slot, 'should have slot name: ' + bid.slot);
+      assert.equal(auctionTargeting[0].type, 'slot', 'should have type: slot');
     });
 
     it('should build page targeting', function() {
@@ -708,8 +709,10 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
       var auctionIdx = TEST_MEDIATOR.getAuctionCount();
       TEST_MEDIATOR.auctionRun[auctionIdx].bids.push(bid);
       var auctionTargeting = TEST_MEDIATOR.buildTargeting_(auctionIdx);
-      assert.equal(auctionTargeting.length, 2, 'should have two targeting objects');
+      assert.equal(auctionTargeting.length, 2, 'should have two targeting objects: one for page targeting, the other for the slot');
+      assert.equal(auctionTargeting[0].bids.length, 0, 'slot should exist, but the targeting should not have bids specifically for the slot');
       assert.isUndefined(auctionTargeting[1].name, 'should have page targeting object');
+      assert.equal(auctionTargeting[1].type, 'page', 'should have type: page');
     });
 
     it('should build slot targeting without a bid', function() {


### PR DESCRIPTION
The `type` property of auction provider targeting objects is deprecated and will be removed in a future release.

[Targeting objects](http://pubfood.org/api-reference#typeDefs-SlotTargetingObject) passed to [AuctionProvider.init](http://pubfood.org/api-reference#pubfood-provider-AuctionProvider-init) and [AuctionProvider.refresh](http://pubfood.org/api-reference#pubfood-provider-AuctionProvider-init) have a `type` property with valid values of:
- `slot`
- `page`

Use the existence of [TargetingObject.name](http://pubfood.org/api-reference#typeDefs-SlotTargetingObject) to indicate the targeting object is for a specific slot i.e. the `name` property. 
