### PR TITLE
fix: emit BID_PUSH_NEXT_LATE

### DIFF
--- a/src/mediator/auctionmediator.js
+++ b/src/mediator/auctionmediator.js
@@ -747,11 +747,12 @@ AuctionMediator.prototype.pushBid = function(auctionIdx, bidObject, providerName
   var bid = Bid.fromObject(bidObject);
   if (bid) {
     bid.provider = providerName;
-    Event.publish(Event.EVENT_TYPE.BID_PUSH_NEXT, bid);
     if (!this.auctionRun[auctionIdx].inAuction) {
       this.auctionRun[auctionIdx].bids.push(bid);
+      Event.publish(Event.EVENT_TYPE.BID_PUSH_NEXT, bid);
     } else {
       this.auctionRun[auctionIdx].lateBids.push(bid);
+      Event.publish(Event.EVENT_TYPE.BID_PUSH_NEXT_LATE, bid);
     }
   } else {
     Event.publish(Event.EVENT_TYPE.WARN, 'Invalid bid object: ' + JSON.stringify(bidObject || {}));

--- a/test/mediator/auctionmediatorlatebids.js
+++ b/test/mediator/auctionmediatorlatebids.js
@@ -78,6 +78,61 @@ describe('Late bids', function () {
     m.start();
   });
 
+  it('should emit a BID_PUSH_NEXT_LATE event', function(done) {
+
+    var m = new AuctionMediator();
+
+    m.addSlot({
+      name: '/abc/123',
+      sizes: [
+        [728, 90]
+      ],
+      elementId: 'div-leaderboard',
+      bidProviders: ['b1']
+    });
+
+    m.addBidProvider({
+      name: 'b1',
+      libUri: '../test/fixture/lib.js',
+      init: function(slots, pushBid, done) {
+        var argPushBid = pushBid;
+        setTimeout(function() {
+          argPushBid({
+            slot: '/abc/123',
+            value: '445',
+            sizes: [728, 90]
+          });
+          done();
+        }, 5);
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+
+    m.setAuctionProvider({
+      name: 'provider1',
+      libUri: '../test/fixture/lib.js',
+      init: function(targeting, done) {
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+
+    Event.on(Event.EVENT_TYPE.BID_PUSH_NEXT_LATE, function() {
+      var lateBids = m.getAuctionRunLateBids(1);
+      assert.equal(lateBids.length, 1, 'should be one late bid');
+      var lateBid = lateBids[0];
+      assert.equal(lateBid.value, 445, 'should be a bid for 445');
+
+      done();
+    });
+    m.timeout(1);
+    m.start();
+  });
+
   it('should keep timely bids separate from late bids', function(done) {
 
     var m = new AuctionMediator();


### PR DESCRIPTION
closes #26 

Bids pushed into the `lateBids` array after the auction provider has started building the publisher ad server request cause `Event.EVENT_TYPE.BID_PUSH_NEXT_LATE` to be emitted.

_[refresh-bid.html](examples/provider/auction/google/refresh-bid.html)_
```
{
  "auctionId": "ijee3eheqdlhkmdpq3:1",
  "ts": 1452784018522,
  "type": "BID_PUSH_NEXT_LATE",
  "eventContext": "pubfood",
  "data": {
    "id": "ijee3exl02hxgqr6sd",
    "params_": {},
    "sizes": [
      300,
      250
    ],
    "value": "1000000.99",
    "type": "string",
    "slot": "/6355419/Travel/Europe/France/Paris",
    "targeting": {
      "ns1_unit": "everything",
      "m1s": "0"
    },
    "auctionIdx": 1,
    "provider": "mock1"
  }
}
```

```
pf.dumpLog('LATE')
Object {ts: 1452784018522, auctionId: "ijee3eheqdlhkmdpq3:1", eventName: "BID_PUSH_NEXT_LATE", event: Object}
Object {ts: 1452784278471, auctionId: "ijee3eheqdlhkmdpq3:2", eventName: "BID_PUSH_NEXT_LATE", event: Object}
```