### PR TITLE
chore: faster test task exit

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,8 @@ var gulp = require('gulp'),
   mocha = require('gulp-mocha'),
   rename = require('gulp-rename'),
   replace = require('gulp-replace'),
-  uglify = require('gulp-uglify');
+  uglify = require('gulp-uglify'),
+  exit = require('gulp-exit');
 
 gulp.task('browserify-unit-tests', function() {
   var b = browserify();
@@ -22,7 +23,8 @@ gulp.task('browserify-unit-tests', function() {
 
 gulp.task('test', function() {
   return gulp.src(['./test/unittestindex.js', './test/apitestindex.js'])
-    .pipe(mocha({reporter: 'spec'}));
+    .pipe(mocha({reporter: 'spec'}))
+    .pipe(exit());
 });
 
 gulp.task('lint', function() {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eventemitter3": "^1.1.1",
     "gulp": "^3.9.0",
     "gulp-eslint": "^1.0.0",
+    "gulp-exit": "0.0.2",
     "gulp-header": "^1.7.1",
     "gulp-mocha": "^2.1.3",
     "gulp-rename": "^1.2.2",


### PR DESCRIPTION
Mocha tests exit swiftly when run directly with mocha. Gulp-mocha however honors `setTimeout` calls. It is not particularly realistic to always `clearTimeout(timeoutId)` for every timeout set in test modules.

The behavior observed is discussed here:
 - https://github.com/sindresorhus/gulp-mocha/pull/31

Add `exit()` to the `test` gulp task.