### PR TITLE
feat: optional bid provider libUri property

### DIFF
--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -41,7 +41,7 @@ auctionDelegate.optional = {
  *
  * @typedef {BidDelegate} BidDelegate
  * @property {string} name Bid provider delegate name.
- * @property {string} libUri location of the delegate JavaScript library/tag.
+ * @property {string} [libUri] location of the delegate JavaScript library/tag.
  * @property {function} init Initial bid request for [BidProvider.init]{@link pubfood#provider.BidProvider#init} delegate.
  * @property {Slot[]} init.slots slots to bid on
  * @property {pushBidCallback} init.pushBid Callback to execute on next bid available
@@ -64,6 +64,7 @@ var bidDelegate = {
   }
 };
 bidDelegate.optional = {
+  libUri: true,
   refresh: true,
   timeout: true
 };

--- a/test/provider/auctionprovider.js
+++ b/test/provider/auctionprovider.js
@@ -16,7 +16,7 @@ describe('Pubfood AuctionProvider', function() {
     var providers = auctionProvider1.valid;
     for (var i = 0; i < providers.length; i++) {
       var ap = AuctionProvider.withDelegate(providers[i]);
-      assert.isDefined(ap, 'auction provider should be created');
+      assert.notEqual(ap, null, 'auction provider should be created');
     }
   });
 

--- a/test/provider/bidprovider.js
+++ b/test/provider/bidprovider.js
@@ -23,47 +23,58 @@ describe('Pubfood BidProvider', function() {
         }
       },
       {
-        name: 'bidder1',
+        name: 'bidder2',
         libUri: '//localhost/cdn/bidder1.js',
         init: function(slots, pushBid, done) {
+        }
+      },
+      {
+        name: 'bidder3',
+        init: function(slots, pushBid, done) {
+        }
+      },
+      {
+        name: 'bidder4',
+        init: function(slots, pushBid, done) {
+        },
+        refresh: function(slots, pushBid, done) {
         }
       }
     ],
     invalid: [
       {
-        name: 'bidder1',
+        name: 'bidder5',
       },
       {
-        name: 'bidder1',
-        init: function(slots, pushBid, done) {
-        }
-      },
-      {
-        name: 'bidder1',
+        name: 'bidder6',
         libUri: '//localhost/cdn/bidder1.js',
         refresh: function(slots, pushBid, done) {
         }
       },
       {
-        name: 'bidder1',
         init: function(slots, pushBid, done) {
         },
         refresh: function(slots, pushBid, done) {
         }
       },
       {
-        init: function(slots, pushBid, done) {
-        },
+        name: 'bidder7',
+        refresh: function(slots, pushBid, done) {
+        }
+      },
+      {
+        libUri: '',
         refresh: function(slots, pushBid, done) {
         }
       }
+
     ]};
 
-  it('should should be valid', function() {
+  it('should be valid', function() {
     var providers = bidProviders.valid;
     for (var i = 0; i < providers.length; i++) {
       var bp = BidProvider.withDelegate(providers[i]);
-      assert.isDefined(bp, 'bid provider should be created');
+      assert.notEqual(bp, null, 'bid provider should not be null:\n' + JSON.stringify(providers[i], null, '  ') + '\n');
     }
   });
 
@@ -72,7 +83,7 @@ describe('Pubfood BidProvider', function() {
     var providers = bidProviders.invalid;
     for (var i = 0; i < providers.length; i++) {
       var ap = BidProvider.withDelegate(providers[i]);
-      assert.isNull(ap, 'bid provider should be created');
+      assert.isNull(ap, 'bid provider object should not have been created');
       var log = logger.history[logger.history.length - 1];
       assert.match(log.event.data.msg, /^Warn: invalid bidder delegate/, 'was not a validation error on delegate');
     }


### PR DESCRIPTION
Allows `libUri` not to be specified in an object passed to `pubfood.addBidProvider()`. e.g.

```
var pf = new pubfood();
pf.addBidProvider({
  name: 'foo',
  init: function(slots, pushBid, done) {}
});
```