### PR TITLE
feat: omit bid provider default key from ad server targeting

### DIFF
--- a/src/mediator/auctionmediator.js
+++ b/src/mediator/auctionmediator.js
@@ -40,6 +40,7 @@ function AuctionMediator(config) {
   this.requestAssembler = new RequestAssembler();
   this.auctionIdx_ = 0;
   this.doneCallbackOffset_ = AuctionMediator.DEFAULT_DONE_CALLBACK_OFFSET;
+  this.omitDefaultBidKey_ = false;
   Event.setAuctionId(this.getAuctionId());
 }
 
@@ -410,8 +411,10 @@ AuctionMediator.prototype.buildTargeting_ = function(auctionIdx) {
         targeting: bid.targeting || {}
       });
 
-      var bidKey = this.getBidKey(bid);
-      tgtObject.targeting[bidKey] = tgtObject.targeting[bidKey] || (bid.value || '');
+      if (!this.omitDefaultBidKey()) {
+        var bidKey = this.getBidKey(bid);
+        tgtObject.targeting[bidKey] = tgtObject.targeting[bidKey] || (bid.value || '');
+      }
       this.mergeKeys(tgtObject.targeting, bid.targeting);
     }
     auctionTargeting.push(tgtObject);
@@ -431,8 +434,10 @@ AuctionMediator.prototype.buildTargeting_ = function(auctionIdx) {
       targeting: bid.targeting
     });
 
-    var bidKey = this.getBidKey(bid);
-    pgTgtObject.targeting[bidKey] = pgTgtObject.targeting[bidKey] || (bid.value || '');
+    if (!this.omitDefaultBidKey()) {
+      var bidKey = this.getBidKey(bid);
+      pgTgtObject.targeting[bidKey] = pgTgtObject.targeting[bidKey] || (bid.value || '');
+    }
     this.mergeKeys(pgTgtObject.targeting, bid.targeting);
   }
   if (pgTgtObject.bids.length > 0) {
@@ -915,6 +920,30 @@ AuctionMediator.prototype.getAuctionRunLateBids = function(auctionIdx) {
 AuctionMediator.prototype.getAuctionRunTargeting = function(auctionIdx) {
   var run = this.auctionRun[auctionIdx];
   return util.asType(run) === 'undefined' ? [] : run.targeting;
+};
+
+/**
+ * Prefix the bid provider default targeting key with the provider name.
+ * @param {boolean} usePrefix turn prefixing off if false. Default: true.
+ * @private
+ */
+AuctionMediator.prototype.prefixDefaultBidKey = function(usePrefix) {
+  if (util.asType(usePrefix) === 'boolean') {
+    this.prefix = usePrefix;
+  }
+  return this.prefix;
+};
+
+/**
+ * Omit sending the bid provider default key/value to ad server.
+ * @param {boolean} defaultBidKeyOff turn bid provider default targeting key off if false. Default: true.
+ * @private
+ */
+AuctionMediator.prototype.omitDefaultBidKey = function(defaultBidKeyOff) {
+  if (util.asType(defaultBidKeyOff) === 'boolean') {
+    this.omitDefaultBidKey_ = defaultBidKeyOff;
+  }
+  return this.omitDefaultBidKey_;
 };
 
 util.extends(AuctionMediator, PubfoodObject);

--- a/src/pubfood.js
+++ b/src/pubfood.js
@@ -385,6 +385,43 @@ var AuctionMediator = require('./mediator/auctionmediator');
     return this;
   };
 
+  /**
+   * Prefix the bid provider default targeting key with the provider name.
+   * @param {boolean} usePrefix turn prefixing off if false. Default: true.
+   * @private
+   */
+  api.prototype.prefixDefaultBidKey = function(usePrefix) {
+    this.mediator.prefixDefaultBidKey(usePrefix);
+    return this;
+  };
+
+  /**
+   * Omit the bid provider default key/value being sent to the ad server.
+   * <p>
+   * Pubfood will add the bid provider default key/value to the ad server
+   * request unless omitted explicitly. Default key of the form: <code>&lt;name&gt;_&lt;label|bid&gt;=&lt;value&gt;</code>
+   * <p>
+   * If the default bid provider key/value is omitted, all ad server targeting
+   * is dependent on the [TargetingObject.targeting]{@link typeDefs.TargetingObject} property.
+   * @param {boolean} defaultBidKeyOff true turns the default bid key/value feature off.
+   * @return {pubfood}
+   * @example
+   *
+   * pubfood.omitDefaultBidKey(true)
+   *
+   * e.g. for the bid provider name: 'foo', prevents the 'foo_bid=' parameters shown below
+   *
+   * prev_iu_szs:300x250|300x600,728x90
+   * prev_scp:foo_bid=400|foo_bid=200
+   *
+   * where;
+   * <bidder>_<label|bid>=<value>
+   */
+  api.prototype.omitDefaultBidKey = function(defaultBidKeyOff) {
+    this.mediator.omitDefaultBidKey(defaultBidKeyOff);
+    return this;
+  };
+
   api.prototype.library = pubfood.library;
 
   global.pubfood = pubfood;

--- a/test/api/buildtargeting.js
+++ b/test/api/buildtargeting.js
@@ -170,7 +170,84 @@ describe('Build slot and page bids', function() {
       for (var i in targeting) {
         var tgtObject = targeting[i];
         if (!tgtObject.name) {
+          assert.equal(targeting[1].targeting.bid_slot, 'any', 'should have bid targeting key \"bid_slot\"');
           assert.equal(targeting[1].targeting.will_bid, 'y', 'should have bid targeting key \"will_bid\"');
+          assert.equal(targeting[1].targeting.bp1_price, 'goobleplex', 'should have <provider>_<label> targeting key \"b1_price\"');
+        }
+      }
+      pfDone();
+
+      done();
+    };
+    pf.start();
+  });
+
+  it('should not prefix bid default key with bid provider name', function(done) {
+    var pf = new pubfood();
+
+    pf.prefixDefaultBidKey(false);
+
+    var slot = pf.addSlot(SLOT);
+    var bidProvider = pf.addBidProvider(BID_PROVIDER);
+    var auctionProvider = pf.setAuctionProvider(AUCTION_PROVIDER);
+    bidProvider.init = function(slots, pushBid, pfDone) {
+      var BID_OBJECT = {
+        value: 'goobleplex',
+        sizes: [[728, 90], [300, 250]],
+        targeting: {
+          will_bid: 'y'
+        },
+        label: 'noBidProviderNamePrefix'
+      };
+      pushBid(BID_OBJECT);
+      pfDone();
+    };
+    auctionProvider.init = function(targeting, pfDone) {
+      assert.equal(targeting.length, 2, 'should have slot AND page level targeting when both added');
+
+      for (var i in targeting) {
+        var tgtObject = targeting[i];
+        if (!tgtObject.name) {
+          assert.equal(targeting[1].targeting.will_bid, 'y', 'should have bid targeting key \"will_bid\"');
+          assert.equal(targeting[1].targeting.noBidProviderNamePrefix, 'goobleplex', 'should have <label> targeting key without the bid provider name prefix');
+        }
+      }
+      pfDone();
+
+      done();
+    };
+    pf.start();
+  });
+
+  it('should omit bid default key from ad server targeting', function(done) {
+    var pf = new pubfood();
+
+    pf.omitDefaultBidKey(true);
+
+    var slot = pf.addSlot(SLOT);
+    var bidProvider = pf.addBidProvider(BID_PROVIDER);
+    var auctionProvider = pf.setAuctionProvider(AUCTION_PROVIDER);
+    bidProvider.init = function(slots, pushBid, pfDone) {
+      var BID_OBJECT = {
+        value: 'goobleplex',
+        sizes: [[728, 90], [300, 250]],
+        targeting: {
+          will_bid: 'y',
+          bid_slot: 'any'
+        },
+        label: 'price'
+      };
+      pushBid(BID_OBJECT);
+      pfDone();
+    };
+    auctionProvider.init = function(targeting, pfDone) {
+      assert.equal(targeting.length, 2, 'should have slot AND page level targeting when both added');
+
+      for (var i in targeting) {
+        var tgtObject = targeting[i];
+        if (!tgtObject.name) {
+          assert.equal(targeting[1].targeting.will_bid, 'y', 'should have bid targeting key \"will_bid\"');
+          assert.isUndefined(targeting[1].targeting.bp1_price, 'should not have default targeting key \"b1_price\"');
         }
       }
       pfDone();

--- a/test/index.html
+++ b/test/index.html
@@ -35,6 +35,7 @@
          }
      );
 
+     pf.omitDefaultBidKey(true);
      var batch = [];
 
      // this reporter listens on all events and pushes the event data to a queue `batch`

--- a/test/mediator/auctionmediator.js
+++ b/test/mediator/auctionmediator.js
@@ -722,6 +722,83 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
       assert.equal(auctionTargeting[0].name, '/abc/123', 'should have slot name');
     });
 
+    it('should turn off bid provider name prefix from default targeting key', function() {
+
+      TEST_MEDIATOR.prefixDefaultBidKey(false);
+
+      var bid = new Bid(87);
+      bid.slot = '/abc/123';
+      bid.provider = 'frotz';
+      bid.targeting = {otherAdServerKey: 87};
+      bid.label = 'price';
+      var auctionIdx = TEST_MEDIATOR.getAuctionCount();
+      TEST_MEDIATOR.auctionRun[auctionIdx].bids.push(bid);
+      var auctionTargeting = TEST_MEDIATOR.buildTargeting_(auctionIdx);
+      assert.equal(auctionTargeting[0].targeting.price, 87, 'should have a default bid targeting key without prefix of bid provider name');
+    });
+
+    it('should turn on bid provider name prefix for default targeting key', function() {
+
+      TEST_MEDIATOR.prefixDefaultBidKey(true);
+
+      var bid = new Bid(87);
+      bid.slot = '/abc/123';
+      bid.provider = 'frotz';
+      var auctionIdx = TEST_MEDIATOR.getAuctionCount();
+      TEST_MEDIATOR.auctionRun[auctionIdx].bids.push(bid);
+      var auctionTargeting = TEST_MEDIATOR.buildTargeting_(auctionIdx);
+      assert.equal(auctionTargeting[0].targeting.frotz_bid, 87, 'should have a default bid targeting key including prefix of bid provider name');
+    });
+
+    it('should omit the bid default key from ad server targeting', function() {
+
+      TEST_MEDIATOR.omitDefaultBidKey(true);
+
+      var bid = new Bid(87);
+      bid.slot = '/abc/123';
+      bid.provider = 'frotz';
+      bid.targeting = {otherAdServerKey: 87};
+      bid.label = 'price';
+      var auctionIdx = TEST_MEDIATOR.getAuctionCount();
+      TEST_MEDIATOR.auctionRun[auctionIdx].bids.push(bid);
+      var auctionTargeting = TEST_MEDIATOR.buildTargeting_(auctionIdx);
+      assert.isUndefined(auctionTargeting[0].targeting.frotz_price, 'should not have a <provider>_<label> bid targeting key');
+      assert.equal(auctionTargeting[0].targeting.otherAdServerKey, 87, 'should have custom targeting set');
+    });
+
+    it('should not omit the bid default key from ad server targeting', function() {
+
+      TEST_MEDIATOR.omitDefaultBidKey(false);
+
+      var bid = new Bid(87);
+      bid.slot = '/abc/123';
+      bid.provider = 'frotz';
+      bid.targeting = {otherAdServerKey: 87};
+      bid.label = 'price';
+      var auctionIdx = TEST_MEDIATOR.getAuctionCount();
+      TEST_MEDIATOR.auctionRun[auctionIdx].bids.push(bid);
+      var auctionTargeting = TEST_MEDIATOR.buildTargeting_(auctionIdx);
+      assert.equal(auctionTargeting[0].targeting.frotz_price, 87, 'should have a <provider>_<label> bid targeting key');
+      assert.equal(auctionTargeting[0].targeting.otherAdServerKey, 87, 'should have custom targeting set');
+    });
+
+    it('should not omit the bid default, non-prefixed, key from ad server targeting', function() {
+
+      TEST_MEDIATOR.omitDefaultBidKey(false);
+      TEST_MEDIATOR.prefixDefaultBidKey(false);
+
+      var bid = new Bid(87);
+      bid.slot = '/abc/123';
+      bid.provider = 'frotz';
+      bid.targeting = {otherAdServerKey: 87};
+      bid.label = 'price';
+      var auctionIdx = TEST_MEDIATOR.getAuctionCount();
+      TEST_MEDIATOR.auctionRun[auctionIdx].bids.push(bid);
+      var auctionTargeting = TEST_MEDIATOR.buildTargeting_(auctionIdx);
+      assert.equal(auctionTargeting[0].targeting.price, 87, 'should have a <label> bid targeting key without bid provider name prefix');
+      assert.equal(auctionTargeting[0].targeting.otherAdServerKey, 87, 'should have custom targeting set');
+    });
+
     it('should build a bid key', function() {
       var bid = new Bid(87);
       for (var i in TEST_MEDIATOR.bidProviders) {


### PR DESCRIPTION
closes #16 
**1).** Add the feature to turn off the bid provider default targeting key from being added to the ad server request. e.g. using this feature will prevent a targeting key such as `partnerX_bid=300` being added to an ad server request.

With the configuration below, _**only**_ `pX=300` will be added to the publisher ad server request.

```
pubfood.omitDefaultBidKey(true);

pubfood.addBidProvider({
  name: 'partnerX',
  init: function(slots, pushBid, done) {
    pushBid({
              slot: '/0000000/mdr',
              value: 300,
              sizes: [[300,250]],
              targeting: {
                pX: 300
              },
              label: 'price'
    });
  }
});
```

**2).** The bid provider name can be omitted from the bid default key (i.e. the name "prefix" to `<name>_<label>`), if the default bid key is used.

With the configuration below, the provider bid key **`label`** and the other custom targeting key **`someOtherKey`**, `pXprice=300&someOtherKey=codeXYZ`, will be added to the publisher ad server request.

```
pubfood.prefixDefaultBidKey(false);

pubfood.addBidProvider({
  name: 'partnerX',
  init: function(slots, pushBid, done) {
    pushBid({
              slot: '/0000000/mdr',
              value: 300,
              sizes: [[300,250]],
              label: 'pXprice',
              targeting: { someOtherKey: 'codeXYZ' }
    });
  }
});
```
