### PR TITLE
fix: allow numeric zero as bid value

### DIFF
--- a/src/mediator/auctionmediator.js
+++ b/src/mediator/auctionmediator.js
@@ -405,7 +405,7 @@ AuctionMediator.prototype.buildTargeting_ = function(auctionIdx) {
     for (var j = 0; j < bidSet.length; j++) {
       var bid = bidSet[j];
       tgtObject.bids.push({
-        value: bid.value || '',
+        value: bid.value,
         provider: bid.provider,
         id: bid.id,
         targeting: bid.targeting || {}
@@ -413,7 +413,7 @@ AuctionMediator.prototype.buildTargeting_ = function(auctionIdx) {
 
       if (!this.omitDefaultBidKey()) {
         var bidKey = this.getBidKey(bid);
-        tgtObject.targeting[bidKey] = tgtObject.targeting[bidKey] || (bid.value || '');
+        tgtObject.targeting[bidKey] = tgtObject.targeting[bidKey] || bid.value;
       }
       this.mergeKeys(tgtObject.targeting, bid.targeting);
     }
@@ -428,7 +428,7 @@ AuctionMediator.prototype.buildTargeting_ = function(auctionIdx) {
     var bid = bidSet[k];
 
     pgTgtObject.bids.push({
-      value: bid.value || '',
+      value: bid.value,
       provider: bid.provider,
       id: bid.id,
       targeting: bid.targeting
@@ -436,7 +436,7 @@ AuctionMediator.prototype.buildTargeting_ = function(auctionIdx) {
 
     if (!this.omitDefaultBidKey()) {
       var bidKey = this.getBidKey(bid);
-      pgTgtObject.targeting[bidKey] = pgTgtObject.targeting[bidKey] || (bid.value || '');
+      pgTgtObject.targeting[bidKey] = pgTgtObject.targeting[bidKey] || bid.value;
     }
     this.mergeKeys(pgTgtObject.targeting, bid.targeting);
   }

--- a/src/model/bid.js
+++ b/src/model/bid.js
@@ -23,7 +23,7 @@ function Bid(value) {
   /** @property {string} [slot] the slot name */
   this.slot;
   /** @property {string|number} value the bid value. Default: empty string */
-  this.value = value || 0;
+  this.value = util.asType(value) === 'undefined' ? '' : value;
   /** @property {string} type derived bid value type: from {@link util.asType}  */
   this.type = util.asType(this.value);
   /** @property {string} [label] optional label for adserver key targeting for bid value e.g. <code>label=2.00</code> */
@@ -57,7 +57,7 @@ Bid.fromObject = function(config) {
  * @return {pubfood#model.Bid}
  */
 Bid.prototype.setValue = function(v) {
-  this.value = v || '';
+  this.value = util.asType(v) === 'undefined' ? '' : v;
   this.type = util.asType(this.value);
   return this;
 };

--- a/test/api/buildtargeting.js
+++ b/test/api/buildtargeting.js
@@ -182,6 +182,45 @@ describe('Build slot and page bids', function() {
     pf.start();
   });
 
+  it('should push a zero slot-level bid and a zero page-level bid', function(done) {
+    var pf = new pubfood();
+    var slot = pf.addSlot(SLOT);
+    var bidProvider = pf.addBidProvider(BID_PROVIDER);
+    var auctionProvider = pf.setAuctionProvider(AUCTION_PROVIDER);
+    bidProvider.init = function(slots, pushBid, pfDone) {
+      var SLOT_BID_OBJECT = {
+        slot: 'slot1',
+        value: 0,
+        sizes: [[300, 250]],
+        targeting: {
+          will_bid: 'y',
+          bid_slot: 'any'
+        },
+        label: 'slot_price'
+      };
+      pushBid(SLOT_BID_OBJECT);
+      var PAGE_BID_OBJECT = {
+        value: 0,
+        sizes: [[300, 250]],
+        targeting: {
+          will_bid: 'y',
+          bid_slot: 'any'
+        },
+        label: 'page_price'
+      };
+      pushBid(PAGE_BID_OBJECT);
+      pfDone();
+    };
+    auctionProvider.init = function(targeting, pfDone) {
+      assert.equal(targeting.length, 2, 'should have slot AND page level targeting when both added');
+      assert.equal(targeting[0].targeting.bp1_slot_price, 0, 'should have slot bid targeting key value of zero');
+      assert.equal(targeting[1].targeting.bp1_page_price, 0, 'should have pabe bid targeting key value of zero');
+      pfDone();
+      done();
+    };
+    pf.start();
+  });
+
   it('should not prefix bid default key with bid provider name', function(done) {
     var pf = new pubfood();
 

--- a/test/mediator/auctionmediator.js
+++ b/test/mediator/auctionmediator.js
@@ -722,6 +722,36 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
       assert.equal(auctionTargeting[0].name, '/abc/123', 'should have slot name');
     });
 
+    it('should build slot and page targeting with a numeric zero bid', function() {
+      var slotBid = Bid.fromObject({ value: 0, slot: '/abc/123', targeting: { zero: 0 }});
+      var pageBid = Bid.fromObject({ value: 0, targeting: { zero: 0 }});
+
+      var auctionIdx = TEST_MEDIATOR.getAuctionCount();
+      TEST_MEDIATOR.auctionRun[auctionIdx].bids.push(slotBid);
+      TEST_MEDIATOR.auctionRun[auctionIdx].bids.push(pageBid);
+      var auctionTargeting = TEST_MEDIATOR.buildTargeting_(auctionIdx);
+
+      assert.equal(auctionTargeting[0].targeting.bid, 0, 'Slot targeting bid value should be zero');
+      assert.equal(auctionTargeting[0].bids[0].value, 0, 'Slot bid value should be zero');
+      assert.equal(auctionTargeting[1].targeting.bid, 0, 'Page targeting bid value should be zero');
+      assert.equal(auctionTargeting[1].bids[0].value, 0, 'Page bid value should be zero');
+    });
+
+    it('should build slot and page targeting with a falsey empty string bid', function() {
+      var slotBid = Bid.fromObject({ value: '', slot: '/abc/123', targeting: { zero: '' }});
+      var pageBid = Bid.fromObject({ value: '', targeting: { zero: '' }});
+
+      var auctionIdx = TEST_MEDIATOR.getAuctionCount();
+      TEST_MEDIATOR.auctionRun[auctionIdx].bids.push(slotBid);
+      TEST_MEDIATOR.auctionRun[auctionIdx].bids.push(pageBid);
+      var auctionTargeting = TEST_MEDIATOR.buildTargeting_(auctionIdx);
+
+      assert.equal(auctionTargeting[0].targeting.bid, '', 'Slot targeting bid value should be an empty string');
+      assert.equal(auctionTargeting[0].bids[0].value, '', 'Slot bid value should be an empty string');
+      assert.equal(auctionTargeting[1].targeting.bid, '', 'Page targeting bid value should be an empty string');
+      assert.equal(auctionTargeting[1].bids[0].value, '', 'Page bid value should be an empty string');
+    });
+
     it('should turn off bid provider name prefix from default targeting key', function() {
 
       TEST_MEDIATOR.prefixDefaultBidKey(false);

--- a/test/model/bid.js
+++ b/test/model/bid.js
@@ -7,6 +7,7 @@
 /*eslint no-undef: 0*/
 var assert = require('chai').assert;
 var Bid = require('../../src/model/bid.js');
+var util = require('../../src/util');
 
 describe('Bid', function testBidBuilder() {
 
@@ -117,5 +118,52 @@ describe('Bid', function testBidBuilder() {
     assert.equal(bid.a, 'a', 'bid.a should be \"a\"');
     assert.equal(bid.b.b, 0, 'bid.b.b should be 0');
     assert.equal(bid.c(), 1, 'bid.c should return 1');
+  });
+
+  it('should create a bid object with a numeric zero value', function() {
+    var bid = Bid.fromObject({});
+    assert.equal(bid.value, 0, 'bid value should be zero (0)');
+
+    bid = Bid.fromObject({ zero: 0 });
+    assert.equal(bid.zero, 0, 'bid key \"zero\" should be zero (0)');
+
+    bid = Bid.fromObject({targeting: { zero: 0 }});
+    assert.equal(bid.targeting.zero, 0, 'bid key \"zero\" should be zero (0)');
+  });
+
+  it('should create a bid object with falsey values', function() {
+    var bid = Bid.fromObject({});
+    assert.equal(bid.value, 0, 'bid value should be zero (0)');
+
+    bid = Bid.fromObject({ value: 0 });
+    assert.equal(bid.value, 0, 'bid key \"value\" should be zero (0)');
+
+    bid = Bid.fromObject({targeting: { empty: '' }});
+    assert.equal(bid.targeting.empty, '', 'bid key \"empty\" should be an empty string');
+
+    bid = Bid.fromObject({targeting: { 'undefined': undefined }});
+    assert.equal(bid.targeting['undefined'], undefined, 'bid key \"undefined\" should be undefined');
+  });
+
+  it('should set Bid object value with falsey values', function() {
+    var bid = new Bid(5);
+    assert.equal(bid.value, 5, 'bid value should be five (5)');
+
+    bid.setValue(0);
+    assert.equal(bid.value, 0, 'bid value should be zero (0)');
+    assert.equal(util.asType(bid.value), 'number', 'bid value should be numeric');
+
+    bid.setValue('');
+    assert.equal(bid.value, '', 'bid value should be an empty string');
+    assert.equal(util.asType(bid.value), 'string', 'bid value should be string');
+
+    bid.setValue(false);
+    assert.equal(bid.value, false, 'bid value should be a boolean false');
+    assert.equal(util.asType(bid.value), 'boolean', 'bid value should be boolean');
+
+    bid.setValue();
+    assert.equal(bid.value, '', 'bid value should be an empty string');
+    assert.equal(util.asType(bid.value), 'string', 'bid value should be a string');
+
   });
 });


### PR DESCRIPTION
Closes #37 

An object of type `number` and value zero (`0`) could not be set to a Bid:
- `Bid(0)`
- `myBid.setValue(0)`

This pull request allows a bid value of numeric zero.