### PR TITLE
Annotate provider complete events if forced by pubfood

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -13,10 +13,9 @@ var EventEmitter = require('eventemitter3');
 /**
  * Pubfood event class
  * @class
- * @property {string} ts The timestamp of the event
- * @property {string} type The event type
- * @property {string} provider The type of provider. Defaults to <i>pubfood</i>
- * @property {object|string} data Data structure for each event type
+ * @property {string} auctionId The auction identifier
+ * @example AuctionId Format - <random string>:<auction count index>
+ * iis9xx46a6v2x58e1b:3
  * @return {PubfoodEvent}
  * @extends EventEmitter
  * @see https://github.com/primus/eventemitter3
@@ -117,6 +116,10 @@ PubfoodEvent.prototype.EVENT_TYPE = {
    * Action is complete
    * @event PubfoodEvent.BID_COMPLETE
    * @property {string} data [BidProvider.name]{@link pubfood#provider.BidProvider}
+   * @property {object} annotations event metadata
+   * @property {string} [annotations.forcedDone] flag to indicate completion was forced
+   * @example
+   * annotations.forcedDone && annotations.forcedDone === 'timeout'
    */
   BID_COMPLETE: 'BID_COMPLETE',
   /**
@@ -203,10 +206,10 @@ PubfoodEvent.prototype.EVENT_TYPE = {
  * publish an event
  * @param {string} eventType The event type
  * @param {*} data the event data
- * @param {string} eventContext The type of provider. ex: <i>bid</i>, <i>auction</i>
+ * @param {object} annotations Contextual metadata for the event
  * @return {boolean} Indication if we've emitted an event.
  */
-PubfoodEvent.prototype.publish = function(eventType, data, eventContext) {
+PubfoodEvent.prototype.publish = function(eventType, data, annotations) {
   var ts = (+new Date());
 
   if (eventType === this.EVENT_TYPE.PUBFOOD_API_START && data) {
@@ -217,7 +220,7 @@ PubfoodEvent.prototype.publish = function(eventType, data, eventContext) {
     auctionId: this.auctionId,
     ts: ts,
     type: eventType,
-    eventContext: eventContext || 'pubfood',
+    annotations: annotations || {},
     data: data || ''
   };
   logger.logEvent(eventType, this.auctionId, event);

--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -185,6 +185,20 @@ var bidObject = {
 };
 
 /**
+ * Event object structure for [observed]{@link pubfood#observe} events.
+ *
+ * @typedef {EventObject} EventObject
+ * @property {string} auctionId the auction identifier
+ * @example AuctionId Format - <random string>:<auction count index>
+ * iis9xx46a6v2x58e1b:3
+ * @property {string} ts the event timestamp
+ * @property {PubfoodEvent#EVENT_TYPE} type the event type
+ * @property {object|string} data the data payload for the [EVENT_TYPE]{@link PubfoodEvent#EVENT_TYPE}
+ * @property {object} annotations event object metadata. See specific [EVENT_TYPE]{@link PubfoodEvent#EVENT_TYPE} for annotatoins
+ * @memberof typeDefs
+ */
+
+/**
  * @typedef {SlotConfig} SlotConfig
  * @property {string} name name of the slot/ad unit in [AuctionProvider]{@link pubfood#provider.AuctionProvider} system e.g. DFP /accountId/mpu-rt
  * @property {string} [elementId] DOM target element id

--- a/test/api/donecallbacktimeout.js
+++ b/test/api/donecallbacktimeout.js
@@ -239,6 +239,7 @@ describe('Provider done callback timeout', function() {
 
     pf.observe('AUCTION_COMPLETE', function(event) {
       clearTimeout(auctionTimeoutId);
+      assert.equal(event.annotations.forcedDone, 'timeout', 'auction complete event should be annotated as forcedDone');
       assert.equal(auctionDone, false, 'pubfood supplied done callback timeout should be used');
       mochaDone();
     });
@@ -289,11 +290,13 @@ describe('Provider done callback timeout', function() {
 
     pf.observe('AUCTION_COMPLETE', function(event) {
       clearTimeout(bidTimeoutId);
+      assert.isUndefined(event.annotations.forcedDone, 'auction complete event should NOT be annotated as forcedDone');
       assert.equal(bidDone, true, 'bid timeout of 1ms should have already fired');
       mochaDone();
     });
 
     pf.observe('BID_COMPLETE', function(event) {
+      assert.equal(event.annotations.forcedDone, 'timeout', 'bid complete event should be annotated as forcedDone');
       assert.equal(auctionDone, false, 'auction timeout of 5ms should not be fired yet');
       bidDone = true;
     });
@@ -344,12 +347,14 @@ describe('Provider done callback timeout', function() {
 
     pf.observe('AUCTION_COMPLETE', function(event) {
       clearTimeout(bidTimeoutId);
+      assert.isUndefined(event.annotations.forcedDone, 'auction complete event should NOT be annotated as forcedDone');
       assert.equal(bidDone, false, 'bid timeout of 5ms should not have fired');
       auctionDone = true;
       mochaDone();
     });
 
     pf.observe('BID_COMPLETE', function(event) {
+      assert.equal(event.annotations.forcedDone, 'timeout', 'bid complete event should be annotated as forcedDone');
       assert.equal(auctionDone, true, 'auction timeout of 1ms should have already fired');
       bidDone = true;
     });
@@ -401,6 +406,7 @@ describe('Provider done callback timeout', function() {
 
     pf.observe('AUCTION_COMPLETE', function(event) {
       clearTimeout(auctionTimeoutId);
+      assert.equal(event.annotations.forcedDone, 'timeout', 'auction complete event should be annotated as forcedDone');
       assert.equal(bidDone, false, 'auctionProvider.timeout(1) should fire before bid flag set');
       assert.equal(auctionDone, false, 'auctionProvider.timeout(1) should fire before bid flag set');
       mochaDone();
@@ -408,6 +414,7 @@ describe('Provider done callback timeout', function() {
 
     pf.observe('BID_COMPLETE', function(event) {
       clearTimeout(bidTimeoutId);
+      assert.equal(event.annotations.forcedDone, 'timeout', 'bid complete event should be annotated as forcedDone');
       assert.equal(bidDone, false, 'auctionProvider.timeout(1) should fire before bid flag set');
       assert.equal(auctionDone, false, 'auctionProvider.timeout(1) should fire before bid flag set');
     });

--- a/test/event/index.js
+++ b/test/event/index.js
@@ -180,4 +180,33 @@ describe('Event - Tests', function () {
     assert.equal(Event.auctionId, 456, 'auctionId should be the number 456');
     done();
   });
+  it('should publish event timestamp', function(done) {
+    var timeRef = (+new Date());
+    Event.on('BID_COMPLETE', function(ev) {
+      assert.isAtLeast(ev.ts, timeRef, 'event timestamp should be less than or equal to timeRef');
+      done();
+    });
+    Event.publish('BID_COMPLETE', 'theBidder');
+  });
+  it('should publish event type', function(done) {
+    Event.on('BID_COMPLETE', function(ev) {
+      assert.equal(ev.type, 'BID_COMPLETE', 'event type should be  \"BID_COMPLETE\"');
+      done();
+    });
+    Event.publish('BID_COMPLETE', 'theBidder');
+  });
+  it('should publish event data', function(done) {
+    Event.publish('BID_COMPLETE', 'theBidder');
+    Event.on('BID_COMPLETE', function(ev) {
+      assert.equal(ev.data, 'theBidder', 'bidder should be \"theBidder\"');
+      done();
+    });
+  });
+  it('should publish event annotations', function(done) {
+    Event.publish('BID_COMPLETE', 'theBidder', {forcedDone: 'test'});
+    Event.on('BID_COMPLETE', function(ev) {
+      assert.equal(ev.annotations.forcedDone, 'test', 'forcedDone annotation should be \"test\"');
+      done();
+    });
+  });
 });

--- a/test/mediator/auctionmediatorlatebids.js
+++ b/test/mediator/auctionmediatorlatebids.js
@@ -217,4 +217,190 @@ describe('Late bids', function () {
     m.timeout(1);
     m.start();
   });
+
+  it('should annotate bid provider with forcedDone', function(done) {
+
+    var m = new AuctionMediator();
+    m.doneCallbackOffset(0);
+    m.timeout(1);
+
+    m.addSlot({
+      name: '/abc/123',
+      sizes: [
+        [728, 90]
+      ],
+      elementId: 'div-leaderboard',
+      bidProviders: ['b1']
+    });
+
+    m.addBidProvider({
+      name: 'b1',
+      libUri: '../test/fixture/lib.js',
+      init: function(slots, pushBid, done) {
+        setTimeout(function() {
+          done();
+        }, 5);
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+
+    m.setAuctionProvider({
+      name: 'provider1',
+      libUri: '../test/fixture/lib.js',
+      init: function(targeting, done) {
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+
+    Event.on(Event.EVENT_TYPE.BID_COMPLETE, function(event) {
+      assert.equal(event.annotations.forcedDone, 'timeout', 'bid provider should have been forced done by timeout');
+      done();
+    });
+
+    m.start();
+  });
+
+  it('if timely, should NOT annotate bid provider with forcedDone', function(done) {
+
+    var m = new AuctionMediator();
+    m.doneCallbackOffset(0);
+    m.timeout(5);
+
+    m.addSlot({
+      name: '/abc/123',
+      sizes: [
+        [728, 90]
+      ],
+      elementId: 'div-leaderboard',
+      bidProviders: ['b1']
+    });
+
+    m.addBidProvider({
+      name: 'b1',
+      libUri: '../test/fixture/lib.js',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+
+    m.setAuctionProvider({
+      name: 'provider1',
+      libUri: '../test/fixture/lib.js',
+      init: function(targeting, done) {
+        setTimeout(function() {
+          done();
+        }, 5);
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+
+    Event.on(Event.EVENT_TYPE.BID_COMPLETE, function(event) {
+      assert.isUndefined(event.annotations.forcedDone, 'bid provider should NOT have been forced done');
+      done();
+    });
+
+    m.start();
+  });
+
+  it('should annotate auction provider with forcedDone', function(done) {
+
+    var m = new AuctionMediator();
+    m.doneCallbackOffset(0);
+    m.timeout(1);
+
+    m.addSlot({
+      name: '/abc/123',
+      sizes: [
+        [728, 90]
+      ],
+      elementId: 'div-leaderboard',
+      bidProviders: ['b1']
+    });
+
+    m.addBidProvider({
+      name: 'b1',
+      libUri: '../test/fixture/lib.js',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+
+    m.setAuctionProvider({
+      name: 'provider1',
+      libUri: '../test/fixture/lib.js',
+      init: function(targeting, done) {
+        setTimeout(function() {
+          done();
+        }, 5);
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+
+    Event.on(Event.EVENT_TYPE.AUCTION_COMPLETE, function(event) {
+      assert.equal(event.annotations.forcedDone, 'timeout', 'auction provider should have been forced done by timeout');
+      done();
+    });
+
+    m.start();
+  });
+
+  it('if timely, should NOT annotate auction provider with forcedDone', function(done) {
+
+    var m = new AuctionMediator();
+    m.doneCallbackOffset(0);
+    m.timeout(5);
+
+    m.addSlot({
+      name: '/abc/123',
+      sizes: [
+        [728, 90]
+      ],
+      elementId: 'div-leaderboard',
+      bidProviders: ['b1']
+    });
+
+    m.addBidProvider({
+      name: 'b1',
+      libUri: '../test/fixture/lib.js',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+
+    m.setAuctionProvider({
+      name: 'provider1',
+      libUri: '../test/fixture/lib.js',
+      init: function(targeting, done) {
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+
+    Event.on(Event.EVENT_TYPE.AUCTION_COMPLETE, function(event) {
+      assert.isUndefined(event.annotations.forcedDone, 'auction provider should NOT have been forced done');
+      done();
+    });
+
+    m.start();
+  });
 });


### PR DESCRIPTION
closes #40 

- Adds `annotations` to event objects passed as the argument to [pubfood.observe](https://github.com/pubfood/pubfood/blob/master/src/pubfood.js#L275)
- For bid and auction providers that have their respective bid [done()](http://pubfood.org/api-reference#typeDefs-bidDoneCallback) and auction [done()](http://pubfood.org/api-reference#typeDefs-auctionDoneCallback) functions called on timeout:
 - annotates the event `annotations` object with `{forcedDone: 'timeout'}`
 - see also [annotate-forced-done/test/api/donecallbacktimeout.js#L407-L420](https://github.com/pubfood/pubfood/blob/annotate-forced-done/test/api/donecallbacktimeout.js#L407-L420)