### PR TITLE
feat(api): expose auction run and callback offset

### DIFF
--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -199,6 +199,22 @@ var bidObject = {
  */
 
 /**
+ * Auction run object structure.
+ *
+ * @typedef {AuctionRun} AuctionRun
+ * @property {string|boolean} inAuction in auction state of false, 'pending' or 'done'
+ * @property {Slot[]} slots slots defined for the auction run
+ * @property {Bid[]} bids bids received for the auction run
+ * @property {Bid[]} lateBids bids received for the auction run
+ * @property {object} bidStatus object keyed by provider name
+ * @property {boolean} bidStatus.?providerName? provider name: completed true|false
+ * @example // bidStatus
+ * var run = pf.getAuctionRun(1),
+    *     aIsDone = run.bidStatus['bidderA'];
+ * @property {TargetingObject[]} targeting ad server targeting used in the auction run
+ */
+
+/**
  * @typedef {SlotConfig} SlotConfig
  * @property {string} name name of the slot/ad unit in [AuctionProvider]{@link pubfood#provider.AuctionProvider} system e.g. DFP /accountId/mpu-rt
  * @property {string} [elementId] DOM target element id

--- a/src/pubfood.js
+++ b/src/pubfood.js
@@ -114,13 +114,35 @@ var AuctionMediator = require('./mediator/auctionmediator');
   };
 
   /**
-   * Get the auction identifier.
+   * Get the auction identifier.<br>
    *
-   * Returns the <id>:<auction count>
+   * Returns the auction identifier key.
+   * @example Auction Id Format
+   * <id>:<auction count>
    * @return {string} the auctionId
    */
   api.prototype.getAuctionId = function() {
     return this.mediator.getAuctionId();
+  };
+
+  /**
+   * Get the auction count.<br>
+   * Returns the latest auction index.
+   * @return {number}
+   */
+  api.prototype.getAuctionCount = function() {
+    return this.mediator.getAuctionCount();
+  };
+
+  /**
+   * Get the auction run data structure.
+   *
+   * @param {number} idx the integer index of the auction run
+   * @return {AuctionRun}
+   * @see [getAuctionCount()]{@link pubfood#getAuctionCount}, for reference to auction run index
+   */
+  api.prototype.getAuctionRun = function(idx) {
+    return this.mediator.getAuctionRun(idx);
   };
 
   /**
@@ -291,28 +313,36 @@ var AuctionMediator = require('./mediator/auctionmediator');
   };
 
   /**
-   * Sets the time in which bid providers must supply bids.
+   * Gets or sets the time in which bid providers must supply bids.
    *
-   * @param {number} millis - milliseconds to set the timeout
+   * @param {number} [millis] - milliseconds to set the timeout
+   * @returns {number} the auction timeout
    */
   api.prototype.timeout = function(millis) {
     this.pushApiCall_('api.timeout', arguments);
-    this.mediator.timeout(millis);
-    return this;
+    if (util.asType(millis) === 'number') {
+      this.mediator.timeout(millis);
+    }
+    return this.mediator.getTimeout();
   };
 
   /**
-   * Sets the default done callback timeout offset. Default: <code>5000ms</code>
+   * Gets or sets the default done callback timeout offset. Default: <code>5000ms</code>
    * <p>
    * If a [BidProvider.timeout]{@link pubfood#provider.BidProvider#timeout} value is not set, specifies the additional time in which a provider gets to push late bids and call [done()]{@link typeDefs.bidDoneCallback}.
    * <p>Assists capturing late bid data for analytics and reporting by giving additional timeout "grace" period.
    * <p>Bid provider timeout calculated as the following if not otherwise set:
    * <li><code>timeout(millis) + doneCallbackOffset(millis)</code></li>
    * <p>If the timeout elapses, done() is called on behalf of the provider.
-   * @param {number} millis - milliseconds to set the timeout
+   * @param {number} [millis] - milliseconds to set the timeout
+   * @returns {number} the done callback offset
    */
   api.prototype.doneCallbackOffset = function(millis) {
-    this.mediator.doneCallbackOffset(millis);
+    this.pushApiCall_('api.doneCallbackOffset', arguments);
+    if (util.asType(millis) === 'number') {
+      this.mediator.doneCallbackOffset(millis);
+    }
+    return this.mediator.getDoneCallbackOffset();
   };
 
   /**

--- a/test/api/auctionrun.js
+++ b/test/api/auctionrun.js
@@ -1,0 +1,147 @@
+/**
+ * pubfood
+ */
+
+/* global describe, it */
+
+'use strict';
+
+/*eslint no-unused-vars: 0*/
+/*eslint no-undef: 0*/
+
+require('../common');
+var pubfood = require('../../src/pubfood');
+var assert = require('chai').assert;
+var expect = require('chai').expect;
+var Event = require('../../src/event');
+
+describe('Pubfood auction run api', function() {
+  beforeEach(function() {
+    Event.removeAllListeners();
+  });
+
+  it('should return auction count of zero if pubfood not configured', function(done) {
+    var pf = new pubfood();
+    pf.timeout(1);
+    assert.equal(pf.getAuctionCount(), 0, 'no auction has started. index should be zero');
+
+    pf.start();
+    assert.equal(pf.getAuctionCount(), 0, 'auction started, but not configured. index should zero');
+
+    done();
+  });
+
+  it('should return auction count greater than zero if configured and start called', function(done) {
+
+    var pf = new pubfood(),
+      isRefresh = false;
+    pf.timeout(1);
+
+    pf.observe('AUCTION_REFRESH', function(event) {
+      isRefresh = true;
+    });
+
+    pf.observe('AUCTION_COMPLETE', function(event) {
+      if (isRefresh) {
+        assert.equal(pf.getAuctionCount(), 2, 'refresh index should be two');
+        done();
+      } else {
+        assert.equal(pf.getAuctionCount(), 1, 'start index should be two');
+      }
+    });
+
+    pf.addSlot({
+      name: '/00000000/medrec',
+      sizes: [
+        [300, 250]
+      ],
+      elementId: 'div-medrec',
+      bidProviders: [
+        'bidderA'
+      ]
+    });
+
+    pf.setAuctionProvider({
+      name: 'auctionProvider',
+      libUri: '../test/fixture/lib.js',
+      init: function(targeting, done) {
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+
+    pf.addBidProvider({
+      name: 'bidderA',
+      libUri: '../test/fixture/lib.js',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+
+    pf.start();
+    pf.refresh();
+  });
+
+  it('should return the auction run by index', function(done) {
+
+    var pf = new pubfood(),
+      isRefresh = false;
+    pf.timeout(1);
+
+    pf.observe('AUCTION_REFRESH', function(event) {
+      isRefresh = true;
+    });
+
+    pf.observe('AUCTION_COMPLETE', function(event) {
+      if (isRefresh) {
+        var bidStatus = pf.getAuctionRun(2).bidStatus;
+        assert.isTrue(bidStatus['bidderA'], 'bidderA should be complete with refresh auction');
+        done();
+      } else {
+        var bidStatus = pf.getAuctionRun(1).bidStatus;
+        assert.isTrue(bidStatus['bidderA'], 'bidderA should be complete with init auction');
+      }
+    });
+
+    pf.addSlot({
+      name: '/00000000/medrec',
+      sizes: [
+        [300, 250]
+      ],
+      elementId: 'div-medrec',
+      bidProviders: [
+        'bidderA'
+      ]
+    });
+
+    pf.setAuctionProvider({
+      name: 'auctionProvider',
+      libUri: '../test/fixture/lib.js',
+      init: function(targeting, done) {
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+
+    pf.addBidProvider({
+      name: 'bidderA',
+      libUri: '../test/fixture/lib.js',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+
+    pf.start();
+    pf.refresh();
+  });
+});

--- a/test/api/donecallbacktimeout.js
+++ b/test/api/donecallbacktimeout.js
@@ -22,6 +22,22 @@ describe('Provider done callback timeout', function() {
     Event.removeAllListeners();
   });
 
+  describe('get / set auction and done callback timeouts', function() {
+    it('should set and return the same timeout() value set', function(done) {
+      var pf = new pubfood();
+      pf.timeout(1000);
+      assert.equal(pf.timeout(), 1000, 'the timeout() value should be the same');
+      done();
+    });
+
+    it('should set and return the same doneCallbackOffset() value set', function(done) {
+      var pf = new pubfood();
+      pf.doneCallbackOffset(1000);
+      assert.equal(pf.doneCallbackOffset(), 1000, 'the doneCallbackOffset() value should be the same');
+      done();
+    });
+  });
+
   describe('with deprecated pubfood config', function() {
     it('should use the callback timeout value from config', function(done) {
       var pf = new pubfood({

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -13,4 +13,5 @@ describe('API - Tests', function () {
   require('./buildtargeting');
   require('./events');
   require('./transformoperator');
+  require('./auctionrun');
 });


### PR DESCRIPTION
closes #47 

Adds to the pubfood API:
- `getAuctionCount()`
- `getAuctionRun(idx)`
- `doneCallbackOffset([millis])`

Behavior changes:
- `timeout()` returns the existing timeout milliseconds

The [API Reference](http://pubfood.org/api-reference#pubfood) doc will be updated in the next formal release. In lieu; refer to JSDOC in [pubfood.js](https://github.com/pubfood/pubfood/blob/master/src/pubfood.js) when merged.