### PR TITLE
feat: wrap provider calls in try/catch

### DIFF
--- a/examples/provider/general/catchprovidererrors.html
+++ b/examples/provider/general/catchprovidererrors.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Catching Provider Errors</title>
+        <script src="../../../build/pubfood.js"></script>
+    </head>
+<body>
+    <h2><em>Catching Provider Errors Example</em></h2>
+    <script>
+     window.googletag = window.googletag || {};
+     googletag.cmd = googletag.cmd || [];
+     var pf = new pubfood();
+     pf.timeout(10000);
+
+     var slot = pf.addSlot({
+         name: '/6355419/Travel/Europe/France/Paris',
+         sizes: [
+             [300, 250]
+         ],
+         elementId: 'div-medrec',
+         bidProviders: [
+             'mock1','mock2'
+         ]
+     });
+
+     var mockProvider1 = pf.addBidProvider({
+         name: 'mock1',
+         init: function(slots, pushBid, done) {
+             throw new Error('TestError-mock1-BidProvider.init')
+             done();
+         },
+         refresh: function(slots, pushBid, done) {
+             throw new Error('TestError-mock1-BidProvider.refresh')
+             done();
+         }
+     });
+
+     pf.setAuctionProvider({
+         name: 'Google',
+         libUri: 'http://www.googletagservices.com/tag/js/gpt.js',
+         init: function(targeting, done) {
+             googletag.cmd.push(function() {
+                 for (var i = 0; i < targeting.length; i++) {
+                     var tgtObject = targeting[i];
+                     var gptObject;
+
+                     if (tgtObject.name) {
+                         gptObject = googletag.defineSlot(tgtObject.name, tgtObject.sizes, tgtObject.elementId)
+                                              .addService(googletag.pubads());
+                     } else {
+                         gptObject = googletag.pubads();
+                     }
+                     for (var p in tgtObject.targeting) {
+                         gptObject.setTargeting(p, tgtObject.targeting[p]);
+                     }
+                 }
+             });
+             googletag.cmd.push(function() {
+                 googletag.pubads().enableSingleRequest();
+                 googletag.enableServices();
+                 done();
+             });
+         },
+         refresh: function(targeting, done) {
+             throw new Error('TestError-Google-AuctionProvider');
+             done();
+         }
+     });
+
+    </script>
+
+    <!-- Ad appended here -->
+    <div id='div-medrec'></div>
+    <p></p>
+    <h4>Open the developer tools and view the console log.</h4>
+    <span>See <a href="./catchprovidererrors.md"><code>catchprovidererrors.md</code></a> for further details.</span>
+    <script type="text/javascript">
+     pf.observe('AUCTION_POST_RUN', function() {
+         googletag.cmd.push(function() {
+             googletag.display('div-medrec');
+         });
+     });
+
+     pf.observe('BID_COMPLETE', function(event) {
+       var forcedDoneAnnotation = event.annotations.forcedDone;
+       var auctionType = event.annotations.auctionType.type;
+       if (forcedDoneAnnotation) {
+         console.log('BID_COMPLETE, Forced done: ' + event.data + ' - ' + auctionType + ', ' + forcedDoneAnnotation.message);
+       }
+     });
+
+     pf.observe('AUCTION_COMPLETE', function(event) {
+       var forcedDoneAnnotation = event.annotations.forcedDone;
+       var auctionType = event.annotations.auctionType.type;
+       if (forcedDoneAnnotation) {
+         console.log('AUCTION_COMPLETE, Forced done: ' + event.data.name + ' - ' + auctionType + ', ' + forcedDoneAnnotation.message);
+         }
+     });
+
+     pf.observe('ERROR', function(event) {
+       console.log('ERROR, ', event.data);
+     });
+
+     pf.start(Date.now(), function(hasErrors, errors) {
+       if (hasErrors) {
+         for (var idx in errors) {
+           console.log('pubfood.start(), Error: ', errors[idx]);
+         }
+       }
+     });
+
+     pf.throwErrors(true);
+     try {
+         pf.refresh();
+     } catch (err) {
+         console.log('With pf.throwErrors(true), we Caught: ' + err.message);
+     }
+    </script>
+
+    </body>
+</html>

--- a/examples/provider/general/catchprovidererrors.md
+++ b/examples/provider/general/catchprovidererrors.md
@@ -1,0 +1,95 @@
+# Pubfood - Handling Provider Errors
+
+In this example you will see how to errors that are raised in:
+
+- Pubfood configuration when <code>pubfood.start(...)</code> is called
+ - [pubfood](https://github.com/pubfood/pubfood/blob/master/src/pubfood.js)
+- Provider <code>init</code> and <code>refresh</code> functions
+ - <code>[AuctionProvider](https://github.com/pubfood/pubfood/blob/master/src/provider/auctionprovider.js)</code>
+ - <code>[BidProvider](https://github.com/pubfood/pubfood/blob/master/src/provider/bidprovider.js)</code>
+
+## Pubfood Configuration Errors
+Use the [API Reference, apiStartCallback](http://pubfood.org/api-reference#typeDefs-apiStartCallback) argument of [pubfood.start()](http://pubfood.org/api-reference#pubfood-start) to respond to configuration errors.
+
+<code>apiStartCallback(hasErrors, errors)</code>
+
+Where;
+ - <code>hasErrors</code> : true if configuration errors exist
+ - <code>errors</code> : array of error messages
+
+<pre>
+     try {
+         pf.start(Date.now(), function(hasErrors, errors) {
+           if (hasErrors) {
+             for (var idx in errors) {
+               console.log('Error: ', errors[idx]);
+             }
+           }
+         });
+     } catch (err) {
+         console.log('Caught: ' + err.message);
+     }
+</pre>
+
+## Provider <code>init</code> and <code>refresh</code> Errors
+Pubfood <code>[AuctionProvider](https://github.com/pubfood/pubfood/blob/master/src/provider/auctionprovider.js)</code> <code>[BidProvider](https://github.com/pubfood/pubfood/blob/master/src/provider/bidprovider.js)</code> `init` and `refresh` functions may produce an unwanted Error.
+
+Pubfood catches provider errors by default and reports the [ERROR](http://pubfood.org/api-reference#PubfoodEvent-ERROR) event. This prevents the error disrupting processing of Pubfood itself and potentially your site implementation.
+
+For example, the bid provider <code>mockProvider1</code> below intentionally throws an Error in each of `init` and `refresh`
+<pre>
+     var mockProvider1 = pf.addBidProvider({
+         name: 'mock1',
+         init: function(slots, pushBid, done) {
+             throw new Error('TestError-mock1-BidProvider.init')
+             done();
+         },
+         refresh: function(slots, pushBid, done) {
+             throw new Error('TestError-mock1-BidProvider.refresh')
+             done();
+         }
+     });
+</pre>
+
+By default, Pubfood will catch these Errors and continue processing, but will ensure that an [ERROR](http://pubfood.org/api-reference#PubfoodEvent-ERROR) event is raised so that it can be handled by the client where necessary as below.
+<pre>
+     pf.observe('ERROR', function(event) {
+       console.log('ERROR, ', event.data);
+     });
+</pre>
+
+Pubfood also allows you to toggle on/off the propogaton of Errors by exposing the interface:
+
+ - <code>[pubfood.throwErrors(silent)](../../../src/pubfood.js#L459-L462)</code>
+
+<pre>
+      var pf = new pubfood();
+      pf.throwErrors(true);
+</pre>
+
+With the `pf.throwErrors(true)` configuration, Errors raised by either <code>[AuctionProvider](https://github.com/pubfood/pubfood/blob/master/src/provider/auctionprovider.js)</code> <code>[BidProvider](https://github.com/pubfood/pubfood/blob/master/src/provider/bidprovider.js)</code> `init` and `refresh` functions should be caught and handled by your client code.
+
+For example, the snippet below shows that `pf.start()` has no `try/catch` handler, yet the `init` function of the bid provider throws an Error: Pubfood catches and handles the Error as the default in this case.
+
+However, before the `pf.refresh()` call, the default error handling in Pubfood is made to re-throw errors by using the API `pf.throwErrors(true)`.
+
+Therefore, the `pf.refresh()` called is wrapped in a `try/catch` to ensure client processing is not disrupted by the bid provider Error.
+
+<pre>
+     pf.start(Date.now(), function(hasErrors, errors) {
+       if (hasErrors) {
+         for (var idx in errors) {
+           console.log('pubfood.start(), Error: ', errors[idx]);
+         }
+       }
+     });
+
+     pf.throwErrors(true);
+     try {
+         pf.refresh();
+     } catch (err) {
+         console.log('With pf.throwErrors(true), we Caught: ' + err.message);
+     }
+</pre>
+
+In both cases, an [ERROR](http://pubfood.org/api-reference#PubfoodEvent-ERROR) event is raised and can be actioned in an event handler as in the `pf.observe('ERROR', function(event) {...});` snippet above.

--- a/examples/provider/general/forceddoneproviderevents.html
+++ b/examples/provider/general/forceddoneproviderevents.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Provider Forced Done Annotations</title>
+        <script src="../../../build/pubfood.js"></script>
+    </head>
+<body>
+    <h2><em>Provider Forced Done Event Annotations Example</em></h2>
+    <script>
+     window.googletag = window.googletag || {};
+     googletag.cmd = googletag.cmd || [];
+
+     var pf = new pubfood();
+     pf.doneCallbackOffset(2);
+     pf.timeout(100);
+
+     var slot = pf.addSlot({
+         name: '/6355419/Travel/Europe/France/Paris',
+         sizes: [
+             [300, 250]
+         ],
+         elementId: 'div-medrec',
+         bidProviders: [
+             'mock1'
+         ]
+     });
+
+     var mockProvider1 = pf.addBidProvider({
+         name: 'mock1',
+         init: function(slots, pushBid, done) {
+           setTimeout(function() {
+             done();
+           }, 125);
+         },
+         refresh: function(slots, pushBid, done) {
+             throw new Error('TestError-mock1-BidProvider')
+             done();
+         }
+     });
+
+     pf.setAuctionProvider({
+         name: 'Google',
+         libUri: 'http://www.googletagservices.com/tag/js/gpt.js',
+         init: function(targeting, done) {
+             googletag.cmd.push(function() {
+                 for (var i = 0; i < targeting.length; i++) {
+                     var tgtObject = targeting[i];
+                     var gptObject;
+
+                     if (tgtObject.name) {
+                         gptObject = googletag.defineSlot(tgtObject.name, tgtObject.sizes, tgtObject.elementId)
+                                              .addService(googletag.pubads());
+                     } else {
+                         gptObject = googletag.pubads();
+                     }
+                     for (var p in tgtObject.targeting) {
+                         gptObject.setTargeting(p, tgtObject.targeting[p]);
+                     }
+                 }
+             });
+             googletag.cmd.push(function() {
+                 googletag.pubads().enableSingleRequest();
+                 googletag.enableServices();
+                 done();
+             });
+         },
+         refresh: function(targeting, done) {
+             throw new Error('TestError-Google-AuctionProvider');
+             done();
+         }
+     });
+
+    </script>
+
+    <!-- Ad appended here -->
+    <div id='div-medrec'></div>
+    <p></p>
+    <h4>Open the developer tools and view the console log.</h4>
+    <span>See <a href="./forceddoneproviderevents.md"><code>forceddoneproviderevents.md</code></a> for further details.</span>
+    <script type="text/javascript">
+     pf.observe('AUCTION_POST_RUN', function() {
+         googletag.cmd.push(function() {
+             googletag.display('div-medrec');
+         });
+     });
+
+     pf.observe('BID_COMPLETE', function(event) {
+       var forcedDoneAnnotation = event.annotations.forcedDone;
+       var auctionType = event.annotations.auctionType.type;
+       if (forcedDoneAnnotation) {
+         console.log('BID_COMPLETE, Forced done (' + forcedDoneAnnotation.type + '): ' + event.data + '\n\t' + auctionType  + ', ' + forcedDoneAnnotation.message);
+       } else {
+         console.log('BID_COMPLETE, Success: ' + event.data + ' - ' + auctionType);
+       }
+     });
+
+     pf.observe('AUCTION_COMPLETE', function(event) {
+       var forcedDoneAnnotation = event.annotations.forcedDone;
+       var auctionType = event.annotations.auctionType.type;
+       if (forcedDoneAnnotation) {
+         console.log('AUCTION_COMPLETE, Forced done (' + forcedDoneAnnotation.type + '): ' + event.data.name + '\n\t' + auctionType + ', ' + event.annotations.forcedDone.message);
+       } else {
+         console.log('AUCTION_COMPLETE, Success: ' + event.data.name + ' - ' + auctionType);
+       }
+     });
+
+     pf.observe('AUCTION_COMPLETE', function(event) {
+       var auctionTypeAnnotation = event.annotations.auctionType;
+       if (auctionTypeAnnotation && auctionTypeAnnotation.type === 'refresh' ) {
+         console.log('### Yes, this was a ' + auctionTypeAnnotation.type + ' AUCTION_COMPLETE ###');
+       }
+     });
+
+     pf.observe('ERROR', function(event) {
+       console.log('ERROR, ', event.data);
+     });
+
+     pf.start(Date.now(), function(hasErrors, errors) {
+       if (hasErrors) {
+         for (var idx in errors) {
+           console.log('pubfood.start(), Error: ', errors[idx]);
+         }
+       }
+     });
+
+     pf.throwErrors(true);
+     try {
+         pf.refresh();
+     } catch (err) {
+         console.log('With pf.throwErrors(true), we Caught: ' + err.message);
+     }
+    </script>
+
+    </body>
+</html>

--- a/examples/provider/general/forceddoneproviderevents.md
+++ b/examples/provider/general/forceddoneproviderevents.md
@@ -1,0 +1,78 @@
+# Provider COMPLETE Events can be "Forced" by Pubfood
+When a provider timeout fires before a provider is complete or an Error occurs during <code>init</code>, <code>refresh</code>, Pubfood
+will call `done()` aka "force" the call on the provider.
+
+The result of a Pubfood forced `done()` call will be the standard BID_COMPLETE and AUCTION_COMPLETE events, but with a [PubfoodEventAnnotation](http://pubfood.org/api-reference#typeDefs-PubfoodEventAnnotation) of type:
+
+ - <code>[PubfoodEvent.ANNOTATION_TYPE.FORCED_DONE](http://pubfood.org/api-reference#PubfoodEvent-ANNOTATION_TYPE)</code>
+
+## BID_COMPLETE and AUCTION_COMPLETE Event Annotations
+
+### <em>Note:</em> Auction Type Annotation
+
+Both the [BID_COMPLETE](http://pubfood.org/api-reference#PubfoodEvent-BID_COMPLETE) and [AUCTION_COMPLETE](http://pubfood.org/api-reference#PubfoodEvent-AUCTION_COMPLETE) events are general in that the event types themselves do not indicate if the COMPLETE event was for an `init` or `refresh` auction.
+
+However, there is <code>[EventObject.annotations.auctionType](http://pubfood.org/api-reference#typeDefs-EventObject)</code> event annotation that provides this information. For example to identify if a `BID_COMPLETE` or `AUCTION_COMPLETE` event is for a `refresh` call you can check the annotations for the event as follows:
+
+<pre>
+     pf.observe('AUCTION_COMPLETE', function(event) {
+       var auctionTypeAnnotation = event.annotations.auctionType;
+       if (auctionTypeAnnotation && auctionTypeAnnotation.type === 'refresh' ) {
+         console.log('### Refresh AUCTION_COMPLETE ###');
+       }
+     });
+</pre>
+
+<blockquote
+<code>### Refresh AUCTION_COMPLETE ###</code>
+</blockquote>
+
+### Forced Done Annotation
+A provider may be forced to COMPLETE for two reasons currently:
+
+1. An Error occurred during `init` or `refresh` processing; or
+2. The provider has not finished processing before the configured timeout occurs.
+
+#### Forced Done by Error or Timeout
+Both the `BID_COMPLETE` and `AUCTION_COMPLETE` events may hava `forcedDone` annotation and observers can check for the type as shown below.
+
+##### `BID_COMPLETE`
+<pre>
+     pf.observe('BID_COMPLETE', function(event) {
+       var forcedDoneAnnotation = event.annotations.forcedDone;
+       var auctionType = event.annotations.auctionType.type;
+       if (forcedDoneAnnotation) {
+         console.log('BID_COMPLETE, Forced done (' + forcedDoneAnnotation.type + '): ' + event.data + '\n\t' + auctionType  + ', ' + forcedDoneAnnotation.message);
+       } else {
+         console.log('BID_COMPLETE, Success: ' + event.data + ' - ' + auctionType);
+       }
+     });
+</pre>
+
+<em>Output from the `BID_COMPLETE` handler</em>
+<blockquote>
+BID_COMPLETE, Forced done (error): mock1<br>
+&nbsp;&nbsp;&nbsp;&nbsp;refresh, TestError-mock1-BidProvider<br>
+BID_COMPLETE, Forced done (timeout): mock1<br>
+&nbsp;&nbsp;&nbsp;&nbsp;init, The bid done callback for "mock1" hasn't been called within the allotted time (0.102sec)
+</blockquote>
+
+##### `AUCTION_COMPLETE`
+<pre>
+     pf.observe('AUCTION_COMPLETE', function(event) {
+       var forcedDoneAnnotation = event.annotations.forcedDone;
+       var auctionType = event.annotations.auctionType.type;
+       if (forcedDoneAnnotation) {
+         console.log('AUCTION_COMPLETE, Forced done (' + forcedDoneAnnotation.type + '): ' + event.data.name + '\n\t' + auctionType + ', ' + event.annotations.forcedDone.message);
+       } else {
+         console.log('AUCTION_COMPLETE, Success: ' + event.data.name + ' - ' + auctionType);
+       }
+     });
+</pre>
+
+<em>Output from the `AUCTION_COMPLETE` handler</em>
+<blockquote>
+AUCTION_COMPLETE, Forced done (error): Google<br>
+&nbsp;&nbsp;&nbsp;&nbsp;refresh, TestError-Google-AuctionProvider<br>
+AUCTION_COMPLETE, Success: Google - init
+</blockquote>

--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -194,7 +194,9 @@ var bidObject = {
  * @property {string} ts the event timestamp
  * @property {PubfoodEvent#EVENT_TYPE} type the event type
  * @property {object|string} data the data payload for the [EVENT_TYPE]{@link PubfoodEvent#EVENT_TYPE}
- * @property {object} annotations event object metadata. See specific [EVENT_TYPE]{@link PubfoodEvent#EVENT_TYPE} for annotatoins
+ * @property {object} annotations event object metadata. See [PubfoodEvent.ANNOTATION_TYPE]{@link PubfoodEvent#ANNOTATION_TYPE} for spcific annotation properties
+ * @property {object} [annotations.auctionType] The auction type annotation, [PubfoodEventAnnotation]{@link typeDefs.PubfoodEventAnnotation}
+ * @property {object} [annotations.forcedDone] The forced done type  annotation, [PubfoodEventAnnotation]{@link typeDefs.PubfoodEventAnnotation}
  * @memberof typeDefs
  */
 
@@ -280,15 +282,22 @@ var PubfoodConfig = {
 };
 
 /**
- * @typedef {AuctionRun} AuctionRun - data pertaining to an init or refresh auction execution
+ * @typedef {AuctionRun} AuctionRun data pertaining to an init or refresh auction execution
  * @property {boolean} inAuction false if bidding still in process
  * @property {array.<Slot>} slots the slots to be filled for the auction
  * @property {array.<Bid>} bids the bids for the auction run
  * @property {array.<Bid>} lateBids bids that did not get pushed before the timeout to participate in the auction
  * @property {object.<string, boolean>} bidStatus flag to indicate if a bid provider is completed bidding
- * @property {array.<TargetingObject>} targeting the targeting objects used in the auction run 
+ * @property {array.<TargetingObject>} targeting the targeting objects used in the auction run
  * @memberof typeDefs
  * @private
+ */
+
+/**
+ * @typedef {PubfoodEventAnnotation} PubfoodEventAnnotation metadata object that is attached to a {@link PubfoodEvent} instance to provided additional contextual information.
+ * @property {string} type the annotation type, {@link PubfoodEvent#ANNOTATION_TYPE}
+ * @property {string} message the description of the annotation
+ * @memberof typeDefs
  */
 
 module.exports = {

--- a/src/provider/bidprovider.js
+++ b/src/provider/bidprovider.js
@@ -7,7 +7,7 @@
 var util = require('../util');
 var BidDelegate = require('../interfaces').BidDelegate;
 var Event = require('../event');
-var PubfoodObject = require('../pubfoodobject');
+var PubfoodProvider = require('./pubfoodprovider');
 
 /**
  * BidProvider implements bidding partner requests.
@@ -16,6 +16,7 @@ var PubfoodObject = require('../pubfoodobject');
  * @param {BidDelegate} delegate the delegate object that implements [libUri()]{@link pubfood#provider.BidProvider#libUri}, [init()]{@link pubfood#provider.BidProvider#init} and [refresh()]{@link pubfood#provider.BidProvider#refresh}
  * @property {string} name the name of the provider
  * @augments PubfoodObject
+ * @augments PubfoodProvider
  * @memberof pubfood#provider
  */
 function BidProvider(bidDelegate) {
@@ -109,7 +110,12 @@ BidProvider.prototype.init = function(slots, pushBid, done) {
 BidProvider.prototype.refresh = function(slots, pushBid, done) {
   var refresh = (this.bidDelegate && this.bidDelegate.refresh) || null;
   if (!refresh) {
-    Event.publish(Event.EVENT_TYPE.WARN, 'BidProvider.bidDelegate.refresh not defined.');
+    var msg = 'BidProvider.bidDelegate.refresh not defined.';
+    Event.publish(Event.EVENT_TYPE.WARN, msg);
+    if (util.asType(done) === 'function') {
+      var errorAnnotation = Event.newEventAnnotation(Event.ANNOTATION_TYPE.FORCED_DONE.NAME, Event.ANNOTATION_TYPE.FORCED_DONE.ERROR, msg);
+      done(errorAnnotation);
+    }
     return;
   }
   refresh(slots, pushBid, done);
@@ -147,5 +153,5 @@ BidProvider.prototype.getTimeout = function() {
   return this.timeout_;
 };
 
-util.extends(BidProvider, PubfoodObject);
+util.extends(BidProvider, PubfoodProvider);
 module.exports = BidProvider;

--- a/src/provider/pubfoodprovider.js
+++ b/src/provider/pubfoodprovider.js
@@ -1,0 +1,34 @@
+/**
+ * pubfood
+ */
+
+'use strict';
+
+var PubfoodObject = require('../pubfoodobject');
+var util = require('../util');
+
+/**
+ * Provider is a base type for pubfood provider types.
+ *
+ * @class
+ */
+function PubfoodProvider() {
+  this.throwErrors_ = false;
+}
+
+/**
+ * Re-throw caught delegate errors.
+ *
+ * Default: false
+ * @param {boolean} silent if true: re-throw errors in [BidDelegate]{@link typeDefs.BidDelegate} and [AuctionDelegate]{@link typeDefs.AuctionDelegate} functions
+ * @return {boolean}
+ */
+PubfoodProvider.prototype.throwErrors = function(silent) {
+  if (util.asType(silent) === 'boolean') {
+    this.throwErrors_ = silent;
+  }
+  return this.throwErrors_;
+};
+
+util.extends(PubfoodProvider, PubfoodObject);
+module.exports = PubfoodProvider;

--- a/src/pubfood.js
+++ b/src/pubfood.js
@@ -395,12 +395,7 @@ var AuctionMediator = require('./mediator/auctionmediator');
     if(typeof startCb === 'function'){
       startCb(configStatus.hasError, configStatus.details);
     }
-
-    // only continue of there aren't any config errors
-    if (!configStatus.hasError) {
-      this.mediator.start(this.randomizeBidRequests_, startTimestamp);
-    }
-
+    this.mediator.start(this.randomizeBidRequests_, startTimestamp);
     return this;
   };
 
@@ -450,6 +445,19 @@ var AuctionMediator = require('./mediator/auctionmediator');
    */
   api.prototype.omitDefaultBidKey = function(defaultBidKeyOff) {
     this.mediator.omitDefaultBidKey(defaultBidKeyOff);
+    return this;
+  };
+
+  /**
+   * Re-throw caught delegate errors.
+   * Default: false<br><br>
+   * The [throwErrors]{@link PubfoodProvider#throwErrors} property for
+   * all [BidDelegate]{@link typeDefs.BidDelegate} and [AuctionDelegate]{@link typeDefs.AuctionDelegate} providers will be set.
+   * @param {boolean} [silent] if true: re-throw errors in [BidDelegate]{@link typeDefs.BidDelegate} and [AuctionDelegate]{@link typeDefs.AuctionDelegate} functions
+   * @return {pubfood}
+   */
+  api.prototype.throwErrors = function(silent) {
+    this.mediator.throwErrors(silent);
     return this;
   };
 

--- a/test/api/auctionrun.js
+++ b/test/api/auctionrun.js
@@ -144,4 +144,61 @@ describe('Pubfood auction run api', function() {
     pf.start();
     pf.refresh();
   });
+
+  it('should return keep the auctionType', function(done) {
+
+    var pf = new pubfood(),
+      isRefresh = false;
+    pf.timeout(1);
+
+
+    pf.observe('AUCTION_COMPLETE', function(event) {
+      var auctionIdx = pf.getAuctionCount();
+      var auctionRun = pf.getAuctionRun(auctionIdx);
+      if (auctionRun.auctionType === 'refresh') {
+        var bidStatus = pf.getAuctionRun(auctionIdx).bidStatus;
+        assert.isTrue(bidStatus['bidderA'], 'bidderA should be complete with refresh auction');
+        done();
+      } else {
+        var bidStatus = pf.getAuctionRun(auctionIdx).bidStatus;
+        assert.isTrue(bidStatus['bidderA'], 'bidderA should be complete with init auction');
+      }
+    });
+
+    pf.addSlot({
+      name: '/00000000/medrec',
+      sizes: [
+        [300, 250]
+      ],
+      elementId: 'div-medrec',
+      bidProviders: [
+        'bidderA'
+      ]
+    });
+
+    pf.setAuctionProvider({
+      name: 'auctionProvider',
+      libUri: '../test/fixture/lib.js',
+      init: function(targeting, done) {
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+
+    pf.addBidProvider({
+      name: 'bidderA',
+      libUri: '../test/fixture/lib.js',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+
+    pf.start();
+    pf.refresh();
+  });
 });

--- a/test/api/donecallbacktimeout.js
+++ b/test/api/donecallbacktimeout.js
@@ -255,7 +255,7 @@ describe('Provider done callback timeout', function() {
 
     pf.observe('AUCTION_COMPLETE', function(event) {
       clearTimeout(auctionTimeoutId);
-      assert.equal(event.annotations.forcedDone, 'timeout', 'auction complete event should be annotated as forcedDone');
+      assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.TIMEOUT);
       assert.equal(auctionDone, false, 'pubfood supplied done callback timeout should be used');
       mochaDone();
     });
@@ -312,7 +312,7 @@ describe('Provider done callback timeout', function() {
     });
 
     pf.observe('BID_COMPLETE', function(event) {
-      assert.equal(event.annotations.forcedDone, 'timeout', 'bid complete event should be annotated as forcedDone');
+      assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.TIMEOUT);
       assert.equal(auctionDone, false, 'auction timeout of 5ms should not be fired yet');
       bidDone = true;
     });
@@ -422,7 +422,7 @@ describe('Provider done callback timeout', function() {
 
     pf.observe('AUCTION_COMPLETE', function(event) {
       clearTimeout(auctionTimeoutId);
-      assert.equal(event.annotations.forcedDone, 'timeout', 'auction complete event should be annotated as forcedDone');
+      assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.TIMEOUT);
       assert.equal(bidDone, false, 'auctionProvider.timeout(1) should fire before bid flag set');
       assert.equal(auctionDone, false, 'auctionProvider.timeout(1) should fire before bid flag set');
       mochaDone();
@@ -430,7 +430,7 @@ describe('Provider done callback timeout', function() {
 
     pf.observe('BID_COMPLETE', function(event) {
       clearTimeout(bidTimeoutId);
-      assert.equal(event.annotations.forcedDone, 'timeout', 'bid complete event should be annotated as forcedDone');
+      assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.TIMEOUT);
       assert.equal(bidDone, false, 'auctionProvider.timeout(1) should fire before bid flag set');
       assert.equal(auctionDone, false, 'auctionProvider.timeout(1) should fire before bid flag set');
     });

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -14,4 +14,6 @@ describe('API - Tests', function () {
   require('./events');
   require('./transformoperator');
   require('./auctionrun');
+  require('./providererrors');
+  require('./timeoutforceddone');
 });

--- a/test/api/providererrors.js
+++ b/test/api/providererrors.js
@@ -1,0 +1,673 @@
+/**
+ * pubfood
+ */
+'use strict';
+
+/*eslint no-unused-vars: 0*/
+/*eslint no-undef: 0*/
+var assert = require('chai').assert;
+var Event = require('../../src/event');
+var logger = require('../../src/logger');
+var util = require('../../src/util');
+var PubfoodError = require('../../src/errors');
+
+require('../common');
+var pubfood = require('../../src/pubfood');
+
+describe('Provider Error Handlers', function() {
+  beforeEach(function() {
+    Event.removeAllListeners();
+  });
+  it('should catch auction provider init errors', function(done) {
+    try {
+      var pf = new pubfood(),
+        TEST_RETHROW_CAUGHT,
+        TEST_BID_COMPLETE_CAUGHT,
+        TEST_AUCTION_COMPLETE_CAUGHT,
+        TEST_ERROR_CAUGHT = false;
+
+      pf.throwErrors(true);
+      pf.timeout(1);
+
+      pf.observe('BID_COMPLETE', function(event) {
+        assert.equal(event.data, 'bidProvider', 'bidProvider should be done');
+        TEST_BID_COMPLETE_CAUGHT = true;
+      });
+      pf.observe('AUCTION_COMPLETE', function(event) {
+        assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.ERROR);
+        TEST_AUCTION_COMPLETE_CAUGHT = true;
+        done();
+      });
+      pf.observe('ERROR', function(event) {
+        assert.equal(event.data.message, 'Test - auctionProvider error', 'should be the test error');
+        TEST_ERROR_CAUGHT = true;
+      });
+
+      pf.addSlot({
+        name: '/00000000/multi-size',
+        sizes: [
+          [300, 250],
+          [300, 600]
+        ],
+        elementId: 'div-multi-size',
+        bidProviders: [
+          'bidProvider'
+        ]
+      });
+
+      pf.setAuctionProvider({
+        name: 'auctionProvider',
+        libUri: '../test/fixture/lib.js',
+        init: function(targeting, done) {
+          throw new Error('Test - auctionProvider error');
+          done();
+        }
+      });
+
+      pf.addBidProvider(      {
+        name: 'bidProvider',
+        init: function(slots, pushBid, done) {
+          done();
+        }
+      });
+
+      pf.start();
+    } catch (err) {
+      assert.equal(err.message, 'Test - auctionProvider error', 'should be the test error rethrown');
+      TEST_RETHROW_CAUGHT = true;
+    } finally {
+      assert.equal(TEST_RETHROW_CAUGHT, true, 'auctionProvider error should have been rethrown');
+      assert.equal(TEST_BID_COMPLETE_CAUGHT, true, 'bidProvider complete event should be raised');
+      assert.equal(TEST_AUCTION_COMPLETE_CAUGHT, true, 'auctionProvider complete event should be raised');
+      assert.equal(TEST_ERROR_CAUGHT, true, 'auctionProvider error event should have been raised');
+    }
+  });
+
+  it('should catch auction provider refresh errors', function(done) {
+    try {
+      var pf = new pubfood(),
+        TEST_RETHROW_CAUGHT,
+        TEST_BID_COMPLETE_CAUGHT,
+        TEST_AUCTION_COMPLETE_CAUGHT,
+        TEST_ERROR_CAUGHT,
+        TEST_AUCTION_START_EVENT = false;
+
+      pf.throwErrors(true);
+      pf.timeout(1);
+
+      pf.observe('BID_COMPLETE', function(event) {
+        if (TEST_AUCTION_START_EVENT) {
+          assert.equal(event.data, 'bidProvider', 'bidProvider should be done');
+          TEST_BID_COMPLETE_CAUGHT = true;
+        }
+      });
+      pf.observe('AUCTION_COMPLETE', function(event) {
+        if (TEST_AUCTION_START_EVENT) {
+          assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.ERROR);
+          TEST_AUCTION_COMPLETE_CAUGHT = true;
+          done();
+        }
+        TEST_AUCTION_START_EVENT = true;
+      });
+      pf.observe('ERROR', function(event) {
+        assert.equal(event.data.message, 'Test - auctionProvider error', 'should be the test error');
+        TEST_ERROR_CAUGHT = true;
+      });
+
+      pf.addSlot({
+        name: '/00000000/multi-size',
+        sizes: [
+          [300, 250],
+          [300, 600]
+        ],
+        elementId: 'div-multi-size',
+        bidProviders: [
+          'bidProvider'
+        ]
+      });
+
+      pf.setAuctionProvider({
+        name: 'auctionProvider',
+        libUri: '../test/fixture/lib.js',
+        init: function(targeting, done) {
+          done();
+        },
+        refresh: function(targeting, done) {
+          throw new Error('Test - auctionProvider error');
+          done();
+        }
+      });
+
+      pf.addBidProvider(      {
+        name: 'bidProvider',
+        init: function(slots, pushBid, done) {
+          done();
+        },
+        refresh: function(slots, pushBid, done) {
+          done();
+        }
+      });
+
+      pf.start();
+      pf.refresh();
+    } catch (err) {
+      assert.equal(err.message, 'Test - auctionProvider error', 'should be the test error rethrown');
+      TEST_RETHROW_CAUGHT = true;
+    } finally {
+      assert.equal(TEST_RETHROW_CAUGHT, true, 'auctionProvider error should have been rethrown');
+      assert.equal(TEST_BID_COMPLETE_CAUGHT, true, 'bidProvider complete event should be raised');
+      assert.equal(TEST_AUCTION_COMPLETE_CAUGHT, true, 'auctionProvider complete event should be raised');
+      assert.equal(TEST_ERROR_CAUGHT, true, 'auctionProvider error event should have been raised');
+    }
+  });
+
+  it('should catch auction provider refresh errors, when bid provider refresh undefined', function(done) {
+    try {
+      var pf = new pubfood(),
+        TEST_RETHROW_CAUGHT,
+        TEST_BID_COMPLETE_CAUGHT,
+        TEST_AUCTION_COMPLETE_CAUGHT,
+        TEST_ERROR_CAUGHT,
+        TEST_AUCTION_START_EVENT = false;
+
+      pf.throwErrors(true);
+      pf.timeout(1);
+
+      pf.observe('BID_COMPLETE', function(event) {
+        if (event.annotations.auctionType && event.annotations.auctionType.type === 'init') {
+          TEST_BID_COMPLETE_CAUGHT = true;
+        }
+      });
+      pf.observe('AUCTION_COMPLETE', function(event) {
+        if (event.annotations.auctionType && event.annotations.auctionType.type === 'refresh') {
+          assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.ERROR);
+          TEST_AUCTION_COMPLETE_CAUGHT = true;
+          done();
+        }
+        TEST_AUCTION_START_EVENT = true;
+      });
+      pf.observe('ERROR', function(event) {
+        assert.equal(event.data.message, 'Test - auctionProvider error', 'should be the test error');
+        TEST_ERROR_CAUGHT = true;
+      });
+
+      pf.addSlot({
+        name: '/00000000/multi-size',
+        sizes: [
+          [300, 250],
+          [300, 600]
+        ],
+        elementId: 'div-multi-size',
+        bidProviders: [
+          'bidProvider'
+        ]
+      });
+
+      pf.setAuctionProvider({
+        name: 'auctionProvider',
+        libUri: '../test/fixture/lib.js',
+        init: function(targeting, done) {
+          done();
+        },
+        refresh: function(targeting, done) {
+          throw new Error('Test - auctionProvider error');
+          done();
+        }
+      });
+
+      pf.addBidProvider(      {
+        name: 'bidProvider',
+        init: function(slots, pushBid, done) {
+          done();
+        }
+      });
+
+      pf.start();
+      pf.refresh();
+    } catch (err) {
+      assert.equal(err.message, 'Test - auctionProvider error', 'should be the test error rethrown');
+      TEST_RETHROW_CAUGHT = true;
+    } finally {
+      assert.equal(TEST_RETHROW_CAUGHT, true, 'auctionProvider error should have been rethrown');
+      assert.equal(TEST_BID_COMPLETE_CAUGHT, true, 'bidProvider complete event should be raised');
+      assert.equal(TEST_AUCTION_COMPLETE_CAUGHT, true, 'auctionProvider complete event should be raised');
+      assert.equal(TEST_ERROR_CAUGHT, true, 'auctionProvider error event should have been raised');
+    }
+  });
+
+  it('should catch bid provider init errors', function(done) {
+    try {
+      var pf = new pubfood(),
+        TEST_RETHROW_CAUGHT,
+        TEST_BID_COMPLETE_CAUGHT,
+        TEST_AUCTION_COMPLETE_CAUGHT,
+        TEST_ERROR_CAUGHT = false;
+
+      pf.throwErrors(true);
+      pf.timeout(1);
+
+      pf.observe('BID_COMPLETE', function(event) {
+        assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.ERROR);
+        TEST_BID_COMPLETE_CAUGHT = true;
+      });
+      pf.observe('AUCTION_COMPLETE', function(event) {
+        assert.equal(event.data.name, 'auctionProvider', 'auctionProvider should be done normally');
+        TEST_AUCTION_COMPLETE_CAUGHT = true;
+        done();
+      });
+      pf.observe('ERROR', function(event) {
+        assert.equal(event.data.message, 'Test - bidProvider error', 'should be the test error');
+        TEST_ERROR_CAUGHT = true;
+      });
+
+      pf.addSlot({
+        name: '/00000000/multi-size',
+        sizes: [
+          [300, 250],
+          [300, 600]
+        ],
+        elementId: 'div-multi-size',
+        bidProviders: [
+          'bidProvider'
+        ]
+      });
+
+      pf.setAuctionProvider({
+        name: 'auctionProvider',
+        libUri: '../test/fixture/lib.js',
+        init: function(targeting, done) {
+          done();
+        },
+        refresh: function(targeting, done) {
+          done();
+        }
+      });
+
+      pf.addBidProvider(      {
+        name: 'bidProvider',
+        init: function(slots, pushBid, done) {
+          throw new Error('Test - bidProvider error');
+          done();
+        },
+        refresh: function(slots, pushBid, done) {
+          done();
+        }
+      });
+
+
+      pf.start();
+      pf.refresh();
+    } catch (err) {
+      assert.equal(err.message, 'Test - bidProvider error', 'should be the test error rethrown');
+      TEST_RETHROW_CAUGHT = true;
+    } finally {
+      assert.equal(TEST_RETHROW_CAUGHT, true, 'bidProvider error should have been rethrown');
+      assert.equal(TEST_BID_COMPLETE_CAUGHT, true, 'bidProvider complete event should be raised');
+      assert.equal(TEST_AUCTION_COMPLETE_CAUGHT, true, 'auctionProvider complete event should be raised');
+      assert.equal(TEST_ERROR_CAUGHT, true, 'bidProvider error event should have been raised');
+    }
+  });
+
+  it('should catch bid provider refresh errors', function(done) {
+    try {
+      var pf = new pubfood(),
+        TEST_RETHROW_CAUGHT,
+        TEST_BID_COMPLETE_CAUGHT,
+        TEST_AUCTION_COMPLETE_CAUGHT,
+        TEST_ERROR_CAUGHT,
+        TEST_AUCTION_START_EVENT = false;
+
+      pf.throwErrors(true);
+      pf.timeout(1);
+
+      pf.observe('BID_COMPLETE', function(event) {
+        if (TEST_AUCTION_START_EVENT) {
+          assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.ERROR);
+          TEST_BID_COMPLETE_CAUGHT = true;
+        }
+      });
+      pf.observe('AUCTION_COMPLETE', function(event) {
+        assert.equal(event.data.name, 'auctionProvider', 'auctionProvider should be done normally');
+        TEST_AUCTION_COMPLETE_CAUGHT = true;
+        if (TEST_AUCTION_START_EVENT) {
+          done();
+        }
+        TEST_AUCTION_START_EVENT = true;
+      });
+      pf.observe('ERROR', function(event) {
+        assert.equal(event.data.message, 'Test - bidProvider error', 'should be the test error');
+        TEST_ERROR_CAUGHT = true;
+      });
+
+      pf.addSlot({
+        name: '/00000000/multi-size',
+        sizes: [
+          [300, 250],
+          [300, 600]
+        ],
+        elementId: 'div-multi-size',
+        bidProviders: [
+          'bidProvider'
+        ]
+      });
+
+      pf.setAuctionProvider({
+        name: 'auctionProvider',
+        libUri: '../test/fixture/lib.js',
+        init: function(targeting, done) {
+          done();
+        },
+        refresh: function(targeting, done) {
+          done();
+        }
+      });
+
+      pf.addBidProvider(      {
+        name: 'bidProvider',
+        init: function(slots, pushBid, done) {
+          done();
+        },
+        refresh: function(slots, pushBid, done) {
+          throw new Error('Test - bidProvider error');
+          done();
+        }
+      });
+
+      pf.start();
+      pf.refresh();
+    } catch (err) {
+      assert.equal(err.message, 'Test - bidProvider error', 'should be the test error rethrown');
+      TEST_RETHROW_CAUGHT = true;
+    } finally {
+      assert.equal(TEST_RETHROW_CAUGHT, true, 'bidProvider error should have been rethrown');
+      assert.equal(TEST_BID_COMPLETE_CAUGHT, true, 'bidProvider complete event should be raised');
+      assert.equal(TEST_AUCTION_COMPLETE_CAUGHT, true, 'auctionProvider complete event should be raised');
+      assert.equal(TEST_ERROR_CAUGHT, true, 'bidProvider error event should have been raised');
+    }
+  });
+
+  it('should allow set throwErrors on bid provider only', function(done) {
+    var pf = new pubfood(),
+      otherAssertions = 0;
+    pf.timeout(1);
+
+    pf.observe('BID_COMPLETE', function(event) {
+      if (event.annotations.auctionType.type === Event.ANNOTATION_TYPE.AUCTION_TYPE.REFRESH) {
+        assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.ERROR);
+        otherAssertions++;
+      } else {
+        assert.propertyVal(event.annotations.auctionType, 'type', Event.ANNOTATION_TYPE.AUCTION_TYPE.INIT);
+        otherAssertions++;
+      }
+    });
+    pf.observe('AUCTION_COMPLETE', function(event) {
+      assert.equal(event.data.name, 'auctionProvider', 'auctionProvider should be done normally');
+      if (event.annotations.auctionType.type === Event.ANNOTATION_TYPE.AUCTION_TYPE.REFRESH) {
+        assert.equal(otherAssertions, 4, 'BID_COMPLETE and ERROR events should have been asserted');
+        done();
+      } else {
+        assert.propertyVal(event.annotations.auctionType, 'type', Event.ANNOTATION_TYPE.AUCTION_TYPE.INIT);
+        otherAssertions++;
+      }
+    });
+    pf.observe('ERROR', function(event) {
+      assert.equal(event.data.message, 'Test - bidProvider error', 'should be the test error');
+      otherAssertions++;
+    });
+
+    pf.addSlot({
+      name: '/00000000/multi-size',
+      sizes: [
+        [300, 250],
+        [300, 600]
+      ],
+      elementId: 'div-multi-size',
+      bidProviders: [
+        'bidProvider'
+      ]
+    });
+
+    pf.setAuctionProvider({
+      name: 'auctionProvider',
+      libUri: '../test/fixture/lib.js',
+      init: function(targeting, done) {
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+
+    var bidProvider =  pf.addBidProvider(      {
+      name: 'bidProvider',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        throw new Error('Test - bidProvider error');
+        done();
+      }
+    });
+
+    pf.start();
+    pf.refresh();
+  });
+
+  it('should allow set throwErrors on auction provider only', function(done) {
+    var pf = new pubfood(),
+      otherAssertions = 0;
+    pf.timeout(1);
+
+    pf.observe('BID_COMPLETE', function(event) {
+      if (event.annotations.auctionType.type === Event.ANNOTATION_TYPE.AUCTION_TYPE.REFRESH) {
+        assert.propertyVal(event.annotations.auctionType, 'type', Event.ANNOTATION_TYPE.AUCTION_TYPE.REFRESH);
+        otherAssertions++;
+      } else {
+        assert.propertyVal(event.annotations.auctionType, 'type', Event.ANNOTATION_TYPE.AUCTION_TYPE.INIT);
+        otherAssertions++;
+      }
+    });
+    pf.observe('AUCTION_COMPLETE', function(event) {
+      if (event.annotations.auctionType.type === Event.ANNOTATION_TYPE.AUCTION_TYPE.INIT) {
+        assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.ERROR);
+        otherAssertions++;
+      } else {
+        assert.equal(otherAssertions, 4, 'BID_COMPLETE, AUCTION_COMPLETE and ERROR events should have been asserted');
+        done();
+      }
+    });
+    pf.observe('ERROR', function(event) {
+      assert.equal(event.data.message, 'Test - auctionProvider error', 'should be the test error');
+      otherAssertions++;
+    });
+
+    pf.addSlot({
+      name: '/00000000/multi-size',
+      sizes: [
+        [300, 250],
+        [300, 600]
+      ],
+      elementId: 'div-multi-size',
+      bidProviders: [
+        'bidProvider'
+      ]
+    });
+
+    pf.setAuctionProvider({
+      name: 'auctionProvider',
+      libUri: '../test/fixture/lib.js',
+      init: function(targeting, done) {
+        throw new Error('Test - auctionProvider error');
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+
+    var bidProvider =  pf.addBidProvider(      {
+      name: 'bidProvider',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+
+    pf.start();
+    pf.refresh();
+  });
+
+  it('should report Error.message to pubfood ERROR event', function(done) {
+    try {
+      var pf = new pubfood(),
+        TEST_RETHROW_CAUGHT,
+        TEST_BID_COMPLETE_CAUGHT,
+        TEST_AUCTION_COMPLETE_CAUGHT,
+        TEST_ERROR_CAUGHT,
+        TEST_API_REFRESH = false;
+
+      pf.throwErrors(true);
+      pf.timeout(1);
+
+      pf.observe('BID_COMPLETE', function(event) {
+        assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.ERROR);
+        TEST_BID_COMPLETE_CAUGHT = true;
+      });
+      pf.observe('AUCTION_COMPLETE', function(event) {
+        assert.equal(event.data.name, 'auctionProvider', 'auctionProvider should be done normally');
+        TEST_AUCTION_COMPLETE_CAUGHT = true;
+        done();
+      });
+      pf.observe('ERROR', function(event) {
+        assert.equal(event.data.message, 'nought is not defined', 'should be the test error');
+        TEST_ERROR_CAUGHT = true;
+      });
+      pf.observe('PUBFOOD_API_REFRESH', function(event) {
+        TEST_API_REFRESH = true;
+      });
+
+      pf.addSlot({
+        name: '/00000000/multi-size',
+        sizes: [
+          [300, 250],
+          [300, 600]
+        ],
+        elementId: 'div-multi-size',
+        bidProviders: [
+          'bidProvider'
+        ]
+      });
+
+      pf.setAuctionProvider({
+        name: 'auctionProvider',
+        libUri: '../test/fixture/lib.js',
+        init: function(targeting, done) {
+          done();
+        },
+        refresh: function(targeting, done) {
+          done();
+        }
+      });
+
+      pf.addBidProvider(      {
+        name: 'bidProvider',
+        init: function(slots, pushBid, done) {
+          var nada = nought;
+          done();
+        },
+        refresh: function(slots, pushBid, done) {
+          var nada = nought;
+          done();
+        }
+      });
+
+      pf.start();
+      pf.refresh();
+    } catch (err) {
+      assert.equal(err.message, 'nought is not defined', 'should be the test error rethrown');
+      TEST_RETHROW_CAUGHT = true;
+    } finally {
+      assert.equal(TEST_RETHROW_CAUGHT, true, 'bidProvider error should have been rethrown');
+      assert.equal(TEST_BID_COMPLETE_CAUGHT, true, 'bidProvider complete event should be raised');
+      assert.equal(TEST_AUCTION_COMPLETE_CAUGHT, true, 'auctionProvider complete event should be raised');
+      assert.equal(TEST_ERROR_CAUGHT, true, 'bidProvider error event should have been raised');
+      assert.equal(TEST_API_REFRESH, false, 'pubfood refresh should have been skipped by error handling');
+    }
+  });
+
+  it('should swallow Error with throwErrors(false), the default, but report Error.message to pubfood ERROR event', function(done) {
+    try {
+      var pf = new pubfood(),
+        TEST_BID_COMPLETE_CAUGHT,
+        TEST_AUCTION_COMPLETE_CAUGHT,
+        TEST_ERROR_CAUGHT,
+        TEST_API_REFRESH = false;
+
+      pf.throwErrors(false);
+      pf.timeout(1);
+
+      pf.observe('BID_COMPLETE', function(event) {
+        assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.ERROR);
+        TEST_BID_COMPLETE_CAUGHT = true;
+      });
+      pf.observe('AUCTION_COMPLETE', function(event) {
+        assert.equal(event.data.name, 'auctionProvider', 'auctionProvider should be done normally');
+        TEST_AUCTION_COMPLETE_CAUGHT = true;
+        if (TEST_API_REFRESH) {
+          done();
+        }
+      });
+      pf.observe('ERROR', function(event) {
+        assert.equal(event.data.message, 'nought is not defined', 'should be the test error');
+        TEST_ERROR_CAUGHT = true;
+      });
+      pf.observe('PUBFOOD_API_REFRESH', function(event) {
+        TEST_API_REFRESH = true;
+      });
+
+      pf.addSlot({
+        name: '/00000000/multi-size',
+        sizes: [
+          [300, 250],
+          [300, 600]
+        ],
+        elementId: 'div-multi-size',
+        bidProviders: [
+          'bidProvider'
+        ]
+      });
+
+      pf.setAuctionProvider({
+        name: 'auctionProvider',
+        libUri: '../test/fixture/lib.js',
+        init: function(targeting, done) {
+          done();
+        },
+        refresh: function(targeting, done) {
+          done();
+        }
+      });
+
+      pf.addBidProvider(      {
+        name: 'bidProvider',
+        init: function(slots, pushBid, done) {
+          var nada = nought;
+          done();
+        },
+        refresh: function(slots, pushBid, done) {
+          var nada = nought;
+          done();
+        }
+      });
+
+      pf.start();
+      pf.refresh();
+    } finally {
+      assert.equal(TEST_BID_COMPLETE_CAUGHT, true, 'bidProvider complete event should be raised');
+      assert.equal(TEST_AUCTION_COMPLETE_CAUGHT, true, 'auctionProvider complete event should be raised');
+      assert.equal(TEST_ERROR_CAUGHT, true, 'bidProvider error event should have been raised');
+    }
+  });
+});

--- a/test/api/timeoutforceddone.js
+++ b/test/api/timeoutforceddone.js
@@ -1,0 +1,131 @@
+/**
+ * pubfood
+ */
+'use strict';
+
+/*eslint no-unused-vars: 0*/
+/*eslint no-undef: 0*/
+var assert = require('chai').assert;
+var Event = require('../../src/event');
+var logger = require('../../src/logger');
+var util = require('../../src/util');
+var PubfoodError = require('../../src/errors');
+
+require('../common');
+var pubfood = require('../../src/pubfood');
+
+describe('Provider forced done by timeout', function() {
+  beforeEach(function() {
+    Event.removeAllListeners();
+  });
+
+  it('should have forcedDone property in BID_COMPLETE event annotations', function(done) {
+    var pf = new pubfood(),
+      TEST_AUCTION_START_EVENT = false;
+
+    pf.throwErrors(true);
+    pf.timeout(3);
+
+    pf.observe('BID_COMPLETE', function(event) {
+      assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.TIMEOUT);
+      if (TEST_AUCTION_START_EVENT) {
+        done();
+      }
+      TEST_AUCTION_START_EVENT = true;
+    });
+    pf.addSlot({
+      name: '/00000000/multi-size',
+      sizes: [
+        [300, 250],
+        [300, 600]
+      ],
+      elementId: 'div-multi-size',
+      bidProviders: [
+        'bidProvider'
+      ]
+    });
+
+    pf.setAuctionProvider({
+      name: 'auctionProvider',
+      libUri: '../test/fixture/lib.js',
+      init: function(targeting, done) {
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+
+    var bidProvider = pf.addBidProvider({
+      name: 'bidProvider',
+      init: function(slots, pushBid, done) {
+        setTimeout(function() {
+          done();
+        }, 3);
+      },
+      refresh: function(slots, pushBid, done) {
+        setTimeout(function() {
+          done();
+        }, 33);
+      }
+    });
+    bidProvider.timeout(1);
+    pf.start();
+    pf.refresh();
+  });
+
+  it('should have forcedDone property in AUCTION_COMPLETE event annotations', function(done) {
+    var pf = new pubfood(),
+      TEST_AUCTION_START_EVENT = false;
+
+    pf.timeout(100);
+
+    pf.observe('AUCTION_COMPLETE', function(event) {
+      assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.TIMEOUT);
+      if (TEST_AUCTION_START_EVENT) {
+        done();
+      }
+      TEST_AUCTION_START_EVENT = true;
+    });
+    pf.addSlot({
+      name: '/00000000/multi-size',
+      sizes: [
+        [300, 250],
+        [300, 600]
+      ],
+      elementId: 'div-multi-size',
+      bidProviders: [
+        'bidProvider'
+      ]
+    });
+
+    var auctionProvider = pf.setAuctionProvider({
+      name: 'auctionProvider',
+      libUri: '../test/fixture/lib.js',
+      init: function(targeting, done) {
+        setTimeout(function() {
+          done();
+        }, 10);
+      },
+      refresh: function(targeting, done) {
+        setTimeout(function() {
+          done();
+        }, 10);
+      }
+    });
+    auctionProvider.timeout(1);
+
+    var bidProvider = pf.addBidProvider({
+      name: 'bidProvider',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+
+    pf.start();
+    pf.refresh();
+  });
+});

--- a/test/api/transformoperator.js
+++ b/test/api/transformoperator.js
@@ -15,6 +15,9 @@ require('../common');
 var pubfood = require('../../src/pubfood');
 
 describe('Transform operator', function() {
+  beforeEach(function() {
+    Event.removeAllListeners();
+  });
 
   it('should add bid data', function(done) {
     var pf = new pubfood();

--- a/test/event/index.js
+++ b/test/event/index.js
@@ -202,10 +202,27 @@ describe('Event - Tests', function () {
       done();
     });
   });
+  it('should create a new event annotation', function(done) {
+    var annotations = Event.newEventAnnotation('forcedDone', 'timeout', 'provided done was called due to timeout');
+    assert.equal(annotations.forcedDone.type, 'timeout', 'forcedDone annotation should be \"timeout\"');
+    assert.equal(annotations.forcedDone.message, 'provided done was called due to timeout', 'forcedDone \"timeout\" annotation message incorrect');
+    done();
+  });
+  it('should create a new event annotation and add to existing object', function(done) {
+    var annotations = {};
+    Event.newEventAnnotation('forcedDone', 'timeout', 'provided done was called due to timeout', annotations);
+    assert.equal(annotations.forcedDone.type, 'timeout', 'forcedDone annotation should be \"timeout\"');
+    assert.equal(annotations.forcedDone.message, 'provided done was called due to timeout', 'forcedDone \"timeout\" annotation message incorrect');
+    done();
+  });
   it('should publish event annotations', function(done) {
-    Event.publish('BID_COMPLETE', 'theBidder', {forcedDone: 'test'});
+    var annotations = {};
+    Event.newEventAnnotation('forcedDone', 'error', 'provided done was called due to error', annotations);
+
+    Event.publish('BID_COMPLETE', 'theBidder', annotations);
     Event.on('BID_COMPLETE', function(ev) {
-      assert.equal(ev.annotations.forcedDone, 'test', 'forcedDone annotation should be \"test\"');
+      assert.equal(ev.annotations.forcedDone.type, 'error', 'forcedDone annotation should be \"error\"');
+      assert.equal(ev.annotations.forcedDone.message, 'provided done was called due to error', 'forcedDone annotation message incorrect');
       done();
     });
   });

--- a/test/mediator/auctionmediatorrefresh.js
+++ b/test/mediator/auctionmediatorrefresh.js
@@ -75,6 +75,7 @@ describe('Auction Refresh', function () {
     TEST_MEDIATOR.refresh(['/abc/123']);
     auctionIdx = TEST_MEDIATOR.getAuctionCount();
     assert.equal(auctionIdx, 2, 'expected auction count to be incremented');
+    assert.equal(TEST_MEDIATOR.getAuctionRunType(2), 'refresh', 'default auctionType should be \"refresh\"');
     done();
   });
 

--- a/test/provider/index.js
+++ b/test/provider/index.js
@@ -6,6 +6,7 @@
 /*eslint no-unused-vars: 0*/
 /*eslint no-undef: 0*/
 describe('Provider - Tests', function () {
+  require('./pubfoodprovider');
   require('./bidprovider');
   require('./auctionprovider');
 });

--- a/test/provider/pubfoodprovider.js
+++ b/test/provider/pubfoodprovider.js
@@ -1,0 +1,42 @@
+/**
+ * pubfood
+ */
+'use strict';
+
+/*eslint no-unused-vars: 0*/
+/*eslint no-undef: 0*/
+var assert = require('chai').assert;
+var PubfoodProvider = require('../../src/provider/pubfoodprovider');
+
+describe('PubfoodProvider', function testPubfoodProvider() {
+  it('should set throwErrors property', function() {
+    var pubfoodProvider = new PubfoodProvider();
+    assert.isFalse(pubfoodProvider.throwErrors());
+  });
+
+  it('should not set throwErrors property unless boolean provided', function() {
+    var pubfoodProvider = new PubfoodProvider();
+    assert.isFalse(pubfoodProvider.throwErrors());
+
+    pubfoodProvider.throwErrors('');
+    assert.isFalse(pubfoodProvider.throwErrors());
+
+    pubfoodProvider.throwErrors('true');
+    assert.isFalse(pubfoodProvider.throwErrors());
+
+    pubfoodProvider.throwErrors(1);
+    assert.isFalse(pubfoodProvider.throwErrors());
+
+    pubfoodProvider.throwErrors({});
+    assert.isFalse(pubfoodProvider.throwErrors());
+
+    pubfoodProvider.throwErrors([]);
+    assert.isFalse(pubfoodProvider.throwErrors());
+
+    pubfoodProvider.throwErrors(function () { return true;});
+    assert.isFalse(pubfoodProvider.throwErrors());
+
+    pubfoodProvider.throwErrors(true);
+    assert.isTrue(pubfoodProvider.throwErrors());
+  });
+});


### PR DESCRIPTION
Adds feature to optionally catch `Error` objects raised in AuctionProvider and BidProvider delegate functions.

`pubfood.throwErrors([true|false])`
`BidProvider.throwErrors([true|false])`
`AuctionProvider.throwErrors([true|false])`

Default is `false`: to catch and handle errors raised in delegate functions by emitting an `ERROR` event that can be further handled by the client. This limits the client exposure to unexpected errors raised during bid and auction processing.

This PR also Closes #51 as a result of exposing an array of `PubfoodEventAnnotation` in the observer function event argument e.g.

```
     pf.observe('BID_COMPLETE', function(event) {
       var forcedDoneAnnotation = event.annotations.forcedDone;
       var auctionType = event.annotations.auctionType.type;
       if (forcedDoneAnnotation) {
         console.log('BID_COMPLETE, Forced done: ' + event.data + ' - ' + auctionType + ', ' + forcedDoneAnnotation.message);
       }
     });
```
See also `typeDef.EventObject` and the examples:

- [catchprovidererrors.html](https://github.com/pubfood/pubfood/blob/provider-error-handler/examples/provider/general/catchprovidererrors.html)
- [forceddoneproviderevents.html](https://github.com/pubfood/pubfood/blob/provider-error-handler/examples/provider/general/forceddoneproviderevents.html)

