### PR TITLE
fix: value and sizes not required for page-level bid

### DIFF
--- a/examples/provider/bid/yieldbot/yieldbot-ex1.html
+++ b/examples/provider/bid/yieldbot/yieldbot-ex1.html
@@ -111,8 +111,6 @@
                  }
 
                  pushBid({
-                     value: bid,
-                     sizes: sizes,
                      targeting: {
                          ybot_ad: 'y',
                          ybot: yieldbot.getPageCriteria()


### PR DESCRIPTION
Closes #58:

- Remove unnecessary [BidObject](http://pubfood.org/api-reference#typeDefs-BidObject) properties for page-level bid.