### PR TITLE
Add API to remove event listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   "main": "./dist/pubfood.js",
   "scripts": {
     "clean": "npm prune --production && rm -fr build",
-    "prepare": "npm install && mkdir -p build",
+    "prepare": "mkdir -p build",
     "lint": "gulp lint",
     "test": "gulp test",
-    "build": "npm run prepare && npm run lint && gulp build && npm run test",
+    "build": "npm install && npm run prepare && npm run lint && gulp build && npm run test",
     "start": "npm run build",
     "release": "PACKAGE_VER=`node -e 'console.log(require(\"./package.json\").version)'` && git commit -m \"v${PACKAGE_VER}\" && git tag -a v${PACKAGE_VER} -m \"v${PACKAGE_VER}\" && git push && git push --tags"
   },

--- a/src/event.js
+++ b/src/event.js
@@ -11,8 +11,9 @@ var logger = require('./logger');
 var EventEmitter = require('eventemitter3');
 
 /**
- * Pubfood event class
+ * @classdesc Pubfood event emitter
  * @class
+ * @hideconstructor
  * @property {string} auctionId The auction identifier
  * @example AuctionId Format - <random string>:<auction count index>
  * iis9xx46a6v2x58e1b:3

--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -215,6 +215,7 @@ var bidObject = {
     *     aIsDone = run.bidStatus['bidderA'];
  * @property {TargetingObject[]} targeting ad server targeting used in the auction run
  * @property {number} timeoutId id of bid timeout
+ * @memberof typeDefs
  */
 
 /**
@@ -298,6 +299,15 @@ var PubfoodConfig = {
  * @typedef {PubfoodEventAnnotation} PubfoodEventAnnotation metadata object that is attached to a {@link PubfoodEvent} instance to provided additional contextual information.
  * @property {string} type the annotation type, {@link PubfoodEvent#ANNOTATION_TYPE}
  * @property {string} message the description of the annotation
+ * @memberof typeDefs
+ */
+
+/**
+ * @typedef {ObserveType} ObserveType The number of times an event observer should execute for respective event name.
+ * <br>
+ * [PubfoodEvent.OBSERVE_TYPE]{@link PubfoodEvent#OBSERVE_TYPE}
+ * @property {number} ONCE <b><code>1</code></b> : execute the observer once per emitted event
+ * @property {number} ALL  <b><code>-1</code></b> : execute the observer on each emitted event
  * @memberof typeDefs
  */
 

--- a/src/mediator/auctionmediator.js
+++ b/src/mediator/auctionmediator.js
@@ -537,7 +537,7 @@ AuctionMediator.prototype.auctionDone = function(auctionIdx, data, annotations) 
   Event.publish(Event.EVENT_TYPE.AUCTION_COMPLETE, { name: data, targeting: auctionTargeting }, annotations);
   setTimeout(function() {
     // push this POST event onto the next tick of the event loop
-    Event.publish(Event.EVENT_TYPE.AUCTION_POST_RUN, data);
+    Event.publish(Event.EVENT_TYPE.AUCTION_POST_RUN, data, annotations);
     // TODO consider if delay should be zero or another default
     // TODO consider if delay should be tweakable
   }, 0);
@@ -1026,6 +1026,17 @@ AuctionMediator.prototype.throwErrors = function(silent) {
     }
   }
   return this.throwErrors_;
+};
+
+/**
+ * Get the [AuctionMediator]{@link pubfood#mediator.AuctionMediator} event emitter instance.
+ * <br><br>  The singleton {@link PubfoodEvent} emitter reference is shared among
+ * {@link pubfood} objects.
+ * @returns {PubfoodEvent} the {@link pubfood} emitter singleton reference
+ * @private
+ */
+AuctionMediator.prototype.getEventEmitter = function() {
+  return Event;
 };
 
 util.extendsObject(AuctionMediator, PubfoodObject);

--- a/src/pubfood.js
+++ b/src/pubfood.js
@@ -461,6 +461,34 @@ var AuctionMediator = require('./mediator/auctionmediator');
     return this;
   };
 
+  /**
+   * Get the <code>pubfood</code> event emitter instance.
+   * @returns {PubfoodEvent} event emitter reference
+   */
+  api.prototype.getEventEmitter = function() {
+    return Event;
+  };
+
+  /**
+   * Remove observers of all [PubfoodEvent.EVENT_TYPE]{@link PubfoodEvent.event:AUCTION_COMPLETE} names
+   * @param {string} [eventName] [PubfoodEvent.EVENT_TYPE]{@link PubfoodEvent.event:AUCTION_COMPLETE} name
+   * <br>If not specified, all observers of all [PubfoodEvent.EVENT_TYPE]{@link PubfoodEvent.event:AUCTION_COMPLETE} names will are removed.
+   * @returns {PubfoodEvent} the event emitter
+   */
+  api.prototype.removeAllListeners = function(eventName) {
+    return Event.removeAllListeners(eventName);
+  };
+
+  /**
+   * Remove the specified observer of the [PubfoodEvent.EVENT_TYPE]{@link PubfoodEvent.event:AUCTION_COMPLETE} type
+   * @param {string} eventName [PubfoodEvent.EVENT_TYPE]{@link PubfoodEvent.event:AUCTION_COMPLETE} name
+   * @param {function} listener the observer function
+   * @returns {PubfoodEvent} the event emitter
+   */
+  api.prototype.removeListener = function(eventName, listener) {
+    return Event.removeListener(eventName, listener);
+  };
+
   api.prototype.library = pubfood.library;
 
   global.pubfood = pubfood;

--- a/src/pubfood.js
+++ b/src/pubfood.js
@@ -286,6 +286,7 @@ var AuctionMediator = require('./mediator/auctionmediator');
    * Add a custom reporter
    * @param {string} [eventType] the event to bind this reporter to
    * @param {reporter} reporter Custom reporter
+   * @param {ObserveType} observeType the number of times to execute the observer per emmitted event
    * @return {pubfood}
    * @example
    var pf = new pubfood();
@@ -294,16 +295,18 @@ var AuctionMediator = require('./mediator/auctionmediator');
    };
    pf.observe(reporter);
    */
-  api.prototype.observe = function(eventType, reporter) {
+  api.prototype.observe = function(eventType, reporter, observeType) {
+    var evtpStr = util.asType(eventType);
+    var observer = evtpStr === 'string' ? reporter : eventType;
     this.pushApiCall_('api.observe', arguments);
-    if (typeof eventType === 'function') {
+    if (evtpStr === 'function') {
       // subscribe the reported to all the available events
       for (var e in Event.EVENT_TYPE) {
-        Event.on(Event.EVENT_TYPE[e], util.bind(eventType, this));
+        Event.on(Event.EVENT_TYPE[e], util.bind(observer, this), observeType);
       }
-    } else if (typeof eventType === 'string') {
+    } else if (evtpStr === 'string') {
       if (Event.EVENT_TYPE[eventType]) {
-        Event.on(Event.EVENT_TYPE[eventType], util.bind(reporter, this));
+        Event.on(Event.EVENT_TYPE[eventType], util.bind(observer, this), observeType);
       } else {
         Event.publish(Event.EVENT_TYPE.WARN, 'Warning: Invalid event type "' + eventType + '"');
       }
@@ -459,14 +462,6 @@ var AuctionMediator = require('./mediator/auctionmediator');
   api.prototype.throwErrors = function(silent) {
     this.mediator.throwErrors(silent);
     return this;
-  };
-
-  /**
-   * Get the <code>pubfood</code> event emitter instance.
-   * @returns {PubfoodEvent} event emitter reference
-   */
-  api.prototype.getEventEmitter = function() {
-    return Event;
   };
 
   /**

--- a/test/api/auctionrun.js
+++ b/test/api/auctionrun.js
@@ -63,7 +63,7 @@ describe('Pubfood auction run api', function() {
 
     pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -74,7 +74,7 @@ describe('Pubfood auction run api', function() {
 
     pf.addBidProvider({
       name: 'bidderA',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         done();
       },
@@ -121,7 +121,7 @@ describe('Pubfood auction run api', function() {
 
     pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -132,7 +132,7 @@ describe('Pubfood auction run api', function() {
 
     pf.addBidProvider({
       name: 'bidderA',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         done();
       },
@@ -178,7 +178,7 @@ describe('Pubfood auction run api', function() {
 
     pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -189,7 +189,7 @@ describe('Pubfood auction run api', function() {
 
     pf.addBidProvider({
       name: 'bidderA',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         done();
       },

--- a/test/api/callbacks.js
+++ b/test/api/callbacks.js
@@ -112,7 +112,7 @@ describe('Callbacks', function() {
     // set the auction provider
     pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -130,7 +130,7 @@ describe('Callbacks', function() {
     var bidProviders = [
       {
         name: 'bidderAvg',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(slots, pushBid, done) {
           done();
         },
@@ -140,7 +140,7 @@ describe('Callbacks', function() {
       },
       {
         name: 'bidderFast',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(slots, pushBid, done) {
           done();
         },
@@ -150,7 +150,7 @@ describe('Callbacks', function() {
       },
       {
         name: 'bidderSlow',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(slots, pushBid, done) {
           done();
         },

--- a/test/api/donecallbacktimeout.js
+++ b/test/api/donecallbacktimeout.js
@@ -18,20 +18,24 @@ var expect = require('chai').expect;
 var Event = require('../../src/event');
 
 describe('Provider done callback timeout', function() {
+  var pf;
   beforeEach(function() {
+    pf = new pubfood();
+    Event.removeAllListeners();
+  });
+  afterEach(function() {
+    pf = null;
     Event.removeAllListeners();
   });
 
   describe('get / set auction and done callback timeouts', function() {
     it('should set and return the same timeout() value set', function(done) {
-      var pf = new pubfood();
       pf.timeout(1000);
       assert.equal(pf.timeout(), 1000, 'the timeout() value should be the same');
       done();
     });
 
     it('should set and return the same doneCallbackOffset() value set', function(done) {
-      var pf = new pubfood();
       pf.doneCallbackOffset(1000);
       assert.equal(pf.doneCallbackOffset(), 1000, 'the doneCallbackOffset() value should be the same');
       done();
@@ -46,7 +50,7 @@ describe('Provider done callback timeout', function() {
       pf.timeout(1000);
       var bidProvider = pf.addBidProvider({
         name: 'bidderAvg',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(slots, pushBid, done) {
           done();
         }
@@ -62,7 +66,7 @@ describe('Provider done callback timeout', function() {
       pf.timeout(1000);
       var bidProvider = pf.addBidProvider({
         name: 'bidderAvg',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(slots, pushBid, done) {
           done();
         }
@@ -72,11 +76,10 @@ describe('Provider done callback timeout', function() {
     });
 
     it('should use the auction mediator default callback timeout offset if config not supplied to pubfood ctor', function(done) {
-      var pf = new pubfood();
       pf.timeout(1000);
       var bidProvider = pf.addBidProvider({
         name: 'bidderAvg',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(slots, pushBid, done) {
           done();
         }
@@ -98,11 +101,7 @@ describe('Provider done callback timeout', function() {
         bidTimeoutId,
         bidNotDone = true;
 
-      pf.observe('BID_COMPLETE', function(event) {
-      });
-
       pf.observe('AUCTION_COMPLETE', function(event) {
-        clearTimeout(bidTimeoutId);
         if (bidNotDone) {
           mochaDone();
         }
@@ -122,7 +121,7 @@ describe('Provider done callback timeout', function() {
 
       pf.setAuctionProvider({
         name: 'auctionProvider',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(targeting, done) {
           done();
         }
@@ -130,7 +129,7 @@ describe('Provider done callback timeout', function() {
 
       pf.addBidProvider({
         name: 'bidderAvg',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(slots, pushBid, done) {
           bidTimeoutId = setTimeout(function() {
             bidNotDone = false;
@@ -155,7 +154,6 @@ describe('Provider done callback timeout', function() {
         auctionTimeoutId;
 
       pf.observe('AUCTION_COMPLETE', function(event) {
-        clearTimeout(auctionTimeoutId);
         assert.equal(auctionDone, false, 'the done callback timeout should complete the auction before flag is set');
         mochaDone();
       });
@@ -174,7 +172,7 @@ describe('Provider done callback timeout', function() {
 
       pf.setAuctionProvider({
         name: 'auctionProvider',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(targeting, done) {
           auctionTimeoutId = setTimeout(function() {
             auctionDone = true;
@@ -185,7 +183,7 @@ describe('Provider done callback timeout', function() {
 
       pf.addBidProvider(      {
         name: 'bidderAvg',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(slots, pushBid, done) {
           done();
         }
@@ -196,7 +194,6 @@ describe('Provider done callback timeout', function() {
   });
 
   it('should use the auction mediator default callback timeout offset', function(done) {
-    var pf = new pubfood();
 
     pf.timeout(50);
 
@@ -205,7 +202,6 @@ describe('Provider done callback timeout', function() {
       auctionDone = false;
 
     pf.observe('AUCTION_COMPLETE', function(event) {
-      clearTimeout(auctionTimeoutId);
       assert.equal(auctionDone, true, 'auction mediator default callback timeout offset should be used');
       mochaDone();
     });
@@ -224,7 +220,7 @@ describe('Provider done callback timeout', function() {
 
     pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         auctionTimeoutId = setTimeout(function() {
           auctionDone = true;
@@ -235,7 +231,7 @@ describe('Provider done callback timeout', function() {
 
     pf.addBidProvider(      {
       name: 'bidderAvg',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         done();
       }
@@ -245,7 +241,6 @@ describe('Provider done callback timeout', function() {
   });
 
   it('should force complete auction processing for auction in 10ms with: bidProvider.timeout(5) and pubfood.doneCallbackOffset(1)', function(done) {
-    var pf = new pubfood();
 
     pf.timeout(5);
     pf.doneCallbackOffset(1);
@@ -254,7 +249,6 @@ describe('Provider done callback timeout', function() {
       auctionDone = false;
 
     pf.observe('AUCTION_COMPLETE', function(event) {
-      clearTimeout(auctionTimeoutId);
       assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.TIMEOUT);
       assert.equal(auctionDone, false, 'pubfood supplied done callback timeout should be used');
       mochaDone();
@@ -274,7 +268,7 @@ describe('Provider done callback timeout', function() {
 
     pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         auctionTimeoutId = setTimeout(function() {
           auctionDone = true;
@@ -285,7 +279,7 @@ describe('Provider done callback timeout', function() {
 
     pf.addBidProvider(      {
       name: 'bidderAvg',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         done();
       }
@@ -295,7 +289,6 @@ describe('Provider done callback timeout', function() {
   });
 
   it('should force complete bid processing for bid in 20ms with: bidProvider.timeout(1) and pubfood.timeout(5)', function(done) {
-    var pf = new pubfood();
 
     pf.timeout(5);
 
@@ -305,11 +298,10 @@ describe('Provider done callback timeout', function() {
       bidDone = false;
 
     pf.observe('AUCTION_COMPLETE', function(event) {
-      clearTimeout(bidTimeoutId);
       assert.isUndefined(event.annotations.forcedDone, 'auction complete event should NOT be annotated as forcedDone');
       assert.equal(bidDone, true, 'bid timeout of 1ms should have already fired');
       mochaDone();
-    });
+    }, null, this);
 
     pf.observe('BID_COMPLETE', function(event) {
       assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.TIMEOUT);
@@ -331,15 +323,17 @@ describe('Provider done callback timeout', function() {
 
     pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
-        done();
+        setTimeout(function() {
+          done();
+        }, 1);
       }
     });
 
     var bidderAvg = pf.addBidProvider({
       name: 'bidderAvg',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         bidTimeoutId = setTimeout(function() {
           done();
@@ -352,7 +346,6 @@ describe('Provider done callback timeout', function() {
   });
 
   it('should force complete bid processing for bid in 20ms with: bidProvider.timeout(5) and pubfood.timeout(1)', function(done) {
-    var pf = new pubfood();
 
     pf.timeout(1);
 
@@ -362,7 +355,6 @@ describe('Provider done callback timeout', function() {
       bidDone = false;
 
     pf.observe('AUCTION_COMPLETE', function(event) {
-      clearTimeout(bidTimeoutId);
       assert.isUndefined(event.annotations.forcedDone, 'auction complete event should NOT be annotated as forcedDone');
       assert.equal(bidDone, false, 'bid timeout of 5ms should not have fired');
       auctionDone = true;
@@ -370,7 +362,7 @@ describe('Provider done callback timeout', function() {
     });
 
     pf.observe('BID_COMPLETE', function(event) {
-      assert.equal(event.annotations.forcedDone, 'timeout', 'bid complete event should be annotated as forcedDone');
+      assert.equal(event.annotations.forcedDone.type, 'timeout', 'bid complete event should be annotated as forcedDone');
       assert.equal(auctionDone, true, 'auction timeout of 1ms should have already fired');
       bidDone = true;
     });
@@ -389,7 +381,7 @@ describe('Provider done callback timeout', function() {
 
     var auctionProvider = pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       }
@@ -397,7 +389,7 @@ describe('Provider done callback timeout', function() {
 
     var bidderAvg = pf.addBidProvider({
       name: 'bidderAvg',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         bidTimeoutId = setTimeout(function() {
           done();
@@ -410,7 +402,6 @@ describe('Provider done callback timeout', function() {
   });
 
   it('should force complete bid(20ms) and auction(20ms) processing with: pubfood.timeout(5) + auctionProvider.timeout(1)', function(done) {
-    var pf = new pubfood();
 
     pf.timeout(5);
 
@@ -421,7 +412,6 @@ describe('Provider done callback timeout', function() {
       auctionTimeoutId;
 
     pf.observe('AUCTION_COMPLETE', function(event) {
-      clearTimeout(auctionTimeoutId);
       assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.TIMEOUT);
       assert.equal(bidDone, false, 'auctionProvider.timeout(1) should fire before bid flag set');
       assert.equal(auctionDone, false, 'auctionProvider.timeout(1) should fire before bid flag set');
@@ -429,10 +419,12 @@ describe('Provider done callback timeout', function() {
     });
 
     pf.observe('BID_COMPLETE', function(event) {
-      clearTimeout(bidTimeoutId);
-      assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.TIMEOUT);
-      assert.equal(bidDone, false, 'auctionProvider.timeout(1) should fire before bid flag set');
-      assert.equal(auctionDone, false, 'auctionProvider.timeout(1) should fire before bid flag set');
+
+      if (pf.getAuctionId() === event.auctionId) {
+        assert.propertyVal(event.annotations.forcedDone, 'type', Event.ANNOTATION_TYPE.FORCED_DONE.TIMEOUT);
+        assert.equal(bidDone, false, 'auctionProvider.timeout(1) should fire before bid flag set');
+        assert.equal(auctionDone, false, 'auctionProvider.timeout(1) should fire before bid flag set');
+      }
     });
 
     pf.addSlot({
@@ -449,7 +441,7 @@ describe('Provider done callback timeout', function() {
 
     var auctionProvider = pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         auctionTimeoutId = setTimeout(function() {
           auctionDone = true;
@@ -461,7 +453,7 @@ describe('Provider done callback timeout', function() {
 
     var bidderAvg = pf.addBidProvider({
       name: 'bidderAvg',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         bidTimeoutId = setTimeout(function() {
           bidDone = true;
@@ -469,32 +461,30 @@ describe('Provider done callback timeout', function() {
         }, 20);
       }
     });
-
+    bidderAvg.timeout(1);
     pf.start();
   });
 
   it('should complete bid(2ms) and auction(2ms) processing with: pubfood.timeout(1) + auctionProvider.timeout(5)', function(done) {
-    var pf = new pubfood();
 
     pf.timeout(1);
 
-    var mochaDone = done,
-      auctionDone = false,
-      bidDone = false,
-      bidTimeoutId,
-      auctionTimeoutId;
+    var testState = {
+      mochaDone: done,
+      auctionDone: false,
+      bidDone: false,
+      bidTimeoutId: '',
+      auctionTimeoutId: ''};
 
     pf.observe('AUCTION_COMPLETE', function(event) {
-      clearTimeout(auctionTimeoutId);
-      assert.equal(bidDone, true, 'bidderAvg.init should complete before auctionProvider.timeout(10)');
-      assert.equal(auctionDone, true, 'auctionProvider.init should complete before auctionProvider.timeout(10)');
-      mochaDone();
+      assert.equal(testState.bidDone, true, 'bidderAvg.init should complete before auctionProvider.timeout(5)');
+      assert.equal(testState.auctionDone, true, 'auctionProvider.init should complete before auctionProvider.timeout(5)');
+      done();
     });
 
     pf.observe('BID_COMPLETE', function(event) {
-      clearTimeout(bidTimeoutId);
-      assert.equal(bidDone, true, 'bidderAvg.init should set the bidDone flag');
-      assert.equal(auctionDone, false, 'auctionProvider.init should complete after after bidDone flag set');
+      assert.equal(testState.bidDone, true, 'bidderAvg.init should set the bidDone flag');
+      assert.equal(testState.auctionDone, false, 'auctionProvider.init should complete after after bidDone flag set');
     });
 
     pf.addSlot({
@@ -509,35 +499,34 @@ describe('Provider done callback timeout', function() {
       ]
     });
 
+    var bidderAvg = pf.addBidProvider({
+      name: 'bidderAvg',
+      libUri: 'fixture/lib.js',
+      init: function(slots, pushBid, done) {
+        testState.bidTimeoutId = setTimeout(function() {
+          testState.bidDone = true;
+          done();
+        }, 2);
+      }
+    });
+
     var auctionProvider = pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
-        auctionTimeoutId = setTimeout(function() {
-          auctionDone = true;
+        testState.auctionTimeoutId = setTimeout(function() {
+          testState.auctionDone = true;
           done();
         }, 2);
       }
     });
     auctionProvider.timeout(5);
 
-    var bidderAvg = pf.addBidProvider({
-      name: 'bidderAvg',
-      libUri: '../test/fixture/lib.js',
-      init: function(slots, pushBid, done) {
-        bidTimeoutId = setTimeout(function() {
-          bidDone = true;
-          done();
-        }, 2);
-      }
-    });
-
     pf.start();
   });
 
   it('should wait for all bidder done callbacks if pf.timeout() not called: no timeout for the auction', function(done) {
 
-    var pf = new pubfood();
 
     var mochaDone = done,
       auctionTimeoutId,
@@ -547,8 +536,6 @@ describe('Provider done callback timeout', function() {
       bidFastDone = false;
 
     pf.observe('AUCTION_COMPLETE', function(event) {
-      clearTimeout(auctionTimeoutId);
-      clearTimeout(bidTimeoutId);
       assert.equal(auctionDone, true, 'the auction done flag should be set');
       assert.equal(bidAvgDone, true, 'bidderAvg should have set the done flag');
       assert.equal(bidFastDone, true, 'bidderFast should have set the done flag');
@@ -569,7 +556,7 @@ describe('Provider done callback timeout', function() {
 
     pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         auctionTimeoutId = setTimeout(function() {
           auctionDone = true;
@@ -580,7 +567,7 @@ describe('Provider done callback timeout', function() {
 
     pf.addBidProvider(      {
       name: 'bidderAvg',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         bidTimeoutId = setTimeout(function() {
           bidAvgDone = true;
@@ -591,7 +578,7 @@ describe('Provider done callback timeout', function() {
 
     pf.addBidProvider(      {
       name: 'bidderFast',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         bidFastDone = true;
         done();

--- a/test/api/events.js
+++ b/test/api/events.js
@@ -122,4 +122,232 @@ describe('Pubfood Events', function() {
     });
     pf.refresh();
   });
+
+  it('should call AUCTION_POST_RUN listeners registered after event emitted', function(done) {
+    var pf = new pubfood();
+    pf.addBidProvider({
+      name: 'bp1',
+      libUri: 'http://',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+    pf.setAuctionProvider({
+      name: 'ap1',
+      libUri: 'http://',
+      init: function(targeting, done) {
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+    pf.addSlot({
+      name: 'slot1',
+      elementId: 'div1',
+      sizes: [[1, 1]],
+      bidProviders: ['bp1']
+    });
+
+    pf.start();
+
+    var isDone = false;
+    pf.observe('AUCTION_POST_RUN', function(event) {
+      isDone = true;
+    });
+
+    pf.observe('AUCTION_POST_RUN', function(event) {
+      assert.equal(isDone, true, 'first observer should be done');
+      done();
+    });
+  });
+
+  it('should call AUCTION_POST_RUN observers once only', function(done) {
+    var pf = new pubfood();
+    pf.addBidProvider({
+      name: 'bp1',
+      libUri: 'http://',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+    pf.setAuctionProvider({
+      name: 'ap1',
+      libUri: 'http://',
+      init: function(targeting, done) {
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+    pf.addSlot({
+      name: 'slot1',
+      elementId: 'div1',
+      sizes: [[1, 1]],
+      bidProviders: ['bp1']
+    });
+
+    pf.start();
+
+    var initIsDone = false;
+    pf.observe('AUCTION_POST_RUN', function(event) {
+      initIsDone = true;
+    });
+
+    pf.refresh();
+
+    pf.observe('AUCTION_POST_RUN', function(event) {
+      assert.equal(initIsDone, true, 'init auction should be complete');
+      done();
+    });
+  });
+
+  it('should remove all event observers', function(done) {
+    var pf = new pubfood();
+    pf.addBidProvider({
+      name: 'bp1',
+      libUri: 'http://',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+    pf.setAuctionProvider({
+      name: 'ap1',
+      libUri: 'http://',
+      init: function(targeting, done) {
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+    pf.addSlot({
+      name: 'slot1',
+      elementId: 'div1',
+      sizes: [[1, 1]],
+      bidProviders: ['bp1']
+    });
+
+    pf.start();
+
+    var initIsDone = false;
+    pf.observe('AUCTION_POST_RUN', function(event) {
+      initIsDone = true;
+    });
+    pf.removeAllListeners();
+
+    pf.refresh();
+
+    pf.observe('AUCTION_POST_RUN', function(event) {
+      assert.equal(initIsDone, false, 'listener removal means initIsDone is expected to be false');
+      done();
+    });
+  });
+
+  it('should remove event observers by event name', function(done) {
+    var pf = new pubfood();
+    pf.addBidProvider({
+      name: 'bp1',
+      libUri: 'http://',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+    pf.setAuctionProvider({
+      name: 'ap1',
+      libUri: 'http://',
+      init: function(targeting, done) {
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+    pf.addSlot({
+      name: 'slot1',
+      elementId: 'div1',
+      sizes: [[1, 1]],
+      bidProviders: ['bp1']
+    });
+
+    pf.start();
+
+    var initIsDone = false;
+    pf.observe('AUCTION_POST_RUN', function(event) {
+      initIsDone = true;
+    });
+    pf.removeAllListeners('AUCTION_POST_RUN');
+
+    pf.refresh();
+
+    pf.observe('AUCTION_POST_RUN', function(event) {
+      assert.equal(initIsDone, false, 'listener removal means initIsDone is expected to be false');
+      done();
+    });
+  });
+
+  it('should remove specific event observers', function(done) {
+    var observerFlag = false;
+    var observer = function(event) {
+      observerFlag = true;
+    };
+
+    var pf = new pubfood();
+    pf.addBidProvider({
+      name: 'bp1',
+      libUri: 'http://',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+    pf.setAuctionProvider({
+      name: 'ap1',
+      libUri: 'http://',
+      init: function(targeting, done) {
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+    pf.addSlot({
+      name: 'slot1',
+      elementId: 'div1',
+      sizes: [[1, 1]],
+      bidProviders: ['bp1']
+    });
+
+    pf.start();
+
+    var initIsDone = false;
+    pf.observe('AUCTION_POST_RUN', function(event) {
+      initIsDone = true;
+    });
+
+    pf.observe('AUCTION_POST_RUN', observer);
+    pf.removeListener('AUCTION_POST_RUN', observer);
+
+    pf.refresh();
+
+    pf.observe('AUCTION_POST_RUN', function(event) {
+      assert.equal(initIsDone, true, 'initIsDone is expected to be true');
+      done();
+    });
+  });
 });

--- a/test/api/events.js
+++ b/test/api/events.js
@@ -209,6 +209,56 @@ describe('Pubfood Events', function() {
     });
   });
 
+  it('should allow AUCTION_POST_RUN observers to listen more than once', function(done) {
+    var pf = new pubfood();
+    pf.removeAllListeners('AUCTION_POST_RUN');
+    pf.addBidProvider({
+      name: 'bp1',
+      libUri: 'http://',
+      init: function(slots, pushBid, done) {
+        done();
+      },
+      refresh: function(slots, pushBid, done) {
+        done();
+      }
+    });
+    pf.setAuctionProvider({
+      name: 'ap1',
+      libUri: 'http://',
+      init: function(targeting, done) {
+        done();
+      },
+      refresh: function(targeting, done) {
+        done();
+      }
+    });
+    pf.addSlot({
+      name: 'slot1',
+      elementId: 'div1',
+      sizes: [[1, 1]],
+      bidProviders: ['bp1']
+    });
+
+    pf.start();
+
+    var initIsDone = false;
+    pf.observe('AUCTION_POST_RUN', function(event) {
+      initIsDone = true;
+    });
+
+    pf.refresh();
+
+    var observerCallCount = 0;
+    pf.observe('AUCTION_POST_RUN', function(event) {
+      observerCallCount++;
+      if (initIsDone && observerCallCount === 2) {
+        assert.equal(initIsDone, true, 'initIsDone is expected to be true');
+        assert.equal(observerCallCount, 2, 'observer expected to be triggered for init and refresh');
+        done();
+      }
+    }, -1);
+  });
+
   it('should remove all event observers', function(done) {
     var pf = new pubfood();
     pf.addBidProvider({

--- a/test/api/providererrors.js
+++ b/test/api/providererrors.js
@@ -57,7 +57,7 @@ describe('Provider Error Handlers', function() {
 
       pf.setAuctionProvider({
         name: 'auctionProvider',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(targeting, done) {
           throw new Error('Test - auctionProvider error');
           done();
@@ -128,7 +128,7 @@ describe('Provider Error Handlers', function() {
 
       pf.setAuctionProvider({
         name: 'auctionProvider',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(targeting, done) {
           done();
         },
@@ -205,7 +205,7 @@ describe('Provider Error Handlers', function() {
 
       pf.setAuctionProvider({
         name: 'auctionProvider',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(targeting, done) {
           done();
         },
@@ -274,7 +274,7 @@ describe('Provider Error Handlers', function() {
 
       pf.setAuctionProvider({
         name: 'auctionProvider',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(targeting, done) {
           done();
         },
@@ -353,7 +353,7 @@ describe('Provider Error Handlers', function() {
 
       pf.setAuctionProvider({
         name: 'auctionProvider',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(targeting, done) {
           done();
         },
@@ -429,7 +429,7 @@ describe('Provider Error Handlers', function() {
 
     pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -495,7 +495,7 @@ describe('Provider Error Handlers', function() {
 
     pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         throw new Error('Test - auctionProvider error');
         done();
@@ -562,7 +562,7 @@ describe('Provider Error Handlers', function() {
 
       pf.setAuctionProvider({
         name: 'auctionProvider',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(targeting, done) {
           done();
         },
@@ -641,7 +641,7 @@ describe('Provider Error Handlers', function() {
 
       pf.setAuctionProvider({
         name: 'auctionProvider',
-        libUri: '../test/fixture/lib.js',
+        libUri: 'fixture/lib.js',
         init: function(targeting, done) {
           done();
         },

--- a/test/api/transformoperator.js
+++ b/test/api/transformoperator.js
@@ -15,12 +15,17 @@ require('../common');
 var pubfood = require('../../src/pubfood');
 
 describe('Transform operator', function() {
+  var pf;
   beforeEach(function() {
+    pf = new pubfood();
+    Event.removeAllListeners();
+  });
+  afterEach(function() {
+    pf = null;
     Event.removeAllListeners();
   });
 
   it('should add bid data', function(done) {
-    var pf = new pubfood();
     var slot = pf.addSlot({
       name: 'slot1',
       elementId: 'div1',
@@ -45,7 +50,7 @@ describe('Transform operator', function() {
 
     var auctionProvider = pf.setAuctionProvider({
       name: 'ap1',
-      libUri: 'http://noop.com/file.js',
+      libUri: 'http://',
       init: function(targeting, pfDone) {
         assert.equal(targeting[0].bids.length, 1, 'there shoud be one bid processed');
         for (var i in targeting) {
@@ -70,7 +75,6 @@ describe('Transform operator', function() {
 
   it('should modify bid data', function(done) {
 
-    var pf = new pubfood();
     var slot = pf.addSlot({
       name: 'slot1',
       elementId: 'div1',
@@ -95,7 +99,7 @@ describe('Transform operator', function() {
 
     var auctionProvider = pf.setAuctionProvider({
       name: 'ap1',
-      libUri: 'http://noop.com/file.js',
+      libUri: 'http://',
       init: function(targeting, pfDone) {
         assert.equal(targeting[0].bids.length, 1, 'there shoud be one bid processed');
         for (var i in targeting) {
@@ -119,7 +123,6 @@ describe('Transform operator', function() {
   });
 
   it('should remove a bid object', function(done) {
-    var pf = new pubfood();
     var slot = pf.addSlot({
       name: 'slot1',
       elementId: 'div1',
@@ -159,7 +162,7 @@ describe('Transform operator', function() {
 
     var auctionProvider = pf.setAuctionProvider({
       name: 'ap1',
-      libUri: 'http://noop.com/file.js',
+      libUri: 'http://',
       init: function(targeting, pfDone) {
         var isSlot2Tested = false;
         for (var k = 0; k < targeting.length; k++) {
@@ -191,7 +194,6 @@ describe('Transform operator', function() {
   });
 
   it('should add a bid object', function(done) {
-    var pf = new pubfood();
     var slot = pf.addSlot({
       name: 'slot1',
       elementId: 'div1',
@@ -215,7 +217,7 @@ describe('Transform operator', function() {
 
     var auctionProvider = pf.setAuctionProvider({
       name: 'ap1',
-      libUri: 'http://noop.com/file.js',
+      libUri: 'http://',
       init: function(targeting, pfDone) {
         var isSlot2Tested = false;
         for (var k = 0; k < targeting.length; k++) {
@@ -249,7 +251,6 @@ describe('Transform operator', function() {
   });
 
   it('should use the returned bid array to add or remove a bid', function(done) {
-    var pf = new pubfood();
     var slot = pf.addSlot({
       name: 'slot1',
       elementId: 'div1',
@@ -288,7 +289,7 @@ describe('Transform operator', function() {
 
     var auctionProvider = pf.setAuctionProvider({
       name: 'ap1',
-      libUri: 'http://noop.com/file.js',
+      libUri: 'http://',
       init: function(targeting, pfDone) {
         var isSlot2Tested = false;
         for (var k = 0; k < targeting.length; k++) {
@@ -327,7 +328,6 @@ describe('Transform operator', function() {
   });
 
   it('should only be called once on getting bids within timeout', function(done) {
-    var pf = new pubfood();
     var slot = pf.addSlot({
       name: 'slot1',
       elementId: 'div1',
@@ -367,7 +367,7 @@ describe('Transform operator', function() {
 
     var auctionProvider = pf.setAuctionProvider({
       name: 'ap1',
-      libUri: 'http://noop.com/file.js',
+      libUri: 'http://',
       init: function(targeting, pfDone) {
         pfDone();
       }
@@ -379,19 +379,20 @@ describe('Transform operator', function() {
       return [bids[0]];
     });
     pf.timeout(30);
-    pf.start();
-    setTimeout(function() {
+
+    pf.observe('AUCTION_COMPLETE', function(event) {
       assert.equal(transformCallCount, 1, 'delegate should be called only once');
       done();
-    }, 50);
+    });
 
+    pf.start();
   });
 
   it('should only be called once on timeout', function(done) {
-    var pf = new pubfood();
 
     pf.throwErrors(true);
-    pf.timeout(30);
+    pf.doneCallbackOffset(1);
+    pf.timeout(3);
 
     pf.addSlot({
       name: 'slot1',
@@ -407,7 +408,7 @@ describe('Transform operator', function() {
 
     pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -421,12 +422,12 @@ describe('Transform operator', function() {
       init: function(slots, pushBid, done) {
         setTimeout(function() {
           done();
-        }, 40);
+        }, 4);
       },
       refresh: function(slots, pushBid, done) {
         setTimeout(function() {
           done();
-        }, 40);
+        }, 4);
       }
     });
     bidProvider.timeout(30);
@@ -435,15 +436,16 @@ describe('Transform operator', function() {
       transformCallCount += 1;
       return bids;
     });
-    pf.start();
-    setTimeout(function() {
+
+    pf.observe('AUCTION_COMPLETE', function(event) {
       assert.equal(transformCallCount, 1, 'delegate should be called only once');
       done();
-    }, 50);
+    });
+
+    pf.start();
   });
 
   it('should be called only once each for timeout of init and refresh', function(done) {
-    var pf = new pubfood();
 
     pf.throwErrors(true);
     pf.timeout(5);
@@ -462,7 +464,7 @@ describe('Transform operator', function() {
 
     pf.setAuctionProvider({
       name: 'auctionProvider',
-      libUri: '../fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -492,16 +494,15 @@ describe('Transform operator', function() {
       hasRefreshed = true;
     });
 
+    pf.observe('AUCTION_COMPLETE', function(event) {
+      if (transformCallCount === 3) {
+        done();
+      }
+    });
+
     pf.start();
     pf.refresh();
     pf.refresh();
-
-    setTimeout(function() {
-      if (hasRefreshed) {
-        assert.equal(transformCallCount, 3, 'delegate should be called thrice');
-        done();
-      }
-    }, 10);
   });
 
 });

--- a/test/event/index.js
+++ b/test/event/index.js
@@ -251,11 +251,10 @@ describe('Event - Tests', function () {
     setTimeout(function() {
       sinon.assert.calledWithExactly(firstListener.getCall(0), 5);
       sinon.assert.calledWithExactly(firstListener.getCall(1), 6);
-      sinon.assert.calledWithExactly(firstListener.getCall(2), 7);
       sinon.assert.calledWithExactly(secondListener.getCall(0), 6);
       sinon.assert.calledWithExactly(secondListener.getCall(1), 7);
       sinon.assert.calledWithExactly(thirdListener.getCall(0), 7);
-      sinon.assert.calledThrice(firstListener);
+      sinon.assert.calledTwice(firstListener);
       sinon.assert.calledTwice(secondListener);
       sinon.assert.calledOnce(thirdListener);
       done();

--- a/test/event/index.js
+++ b/test/event/index.js
@@ -60,24 +60,163 @@ describe('Event - Tests', function () {
 
     done();
   });
+  it('should remove all listeners of the specified event name', function(done) {
+    var spyHello = sinon.spy();
+    var spyGoodbye = sinon.spy();
+
+    Event.on('hello', spyHello);
+    Event.on('goodbye', spyGoodbye);
+
+    assert.equal(Event.listeners('hello').length, 1, 'should be one hello listener');
+    assert.equal(Event.listeners('goodbye').length, 1, 'should be one goodbye listener');
+
+    Event.emit('hello', 1);
+    Event.emit('goodbye', 1);
+    sinon.assert.calledOnce(spyHello);
+    sinon.assert.calledOnce(spyGoodbye);
+
+    Event.removeAllListeners('goodbye');
+
+    assert.equal(Event.listeners('hello').length, 1, 'should be one hello listener');
+    assert.equal(Event.listeners('goodbye').length, 0, 'should be zero goodbye listeners');
+
+    Event.emit('hello', 1);
+    Event.emit('goodbye', 1);
+
+    sinon.assert.calledTwice(spyHello);
+    sinon.assert.calledOnce(spyGoodbye);
+
+    done();
+  });
   it('should remove immediate listeners', function(done) {
     var spy = sinon.spy();
 
-    Event.emit('hello'); // call-1
-    Event.on('hello', spy); // hello listener 1
+    Event.emit('hello');
+    Event.on('hello', spy);
     sinon.assert.calledOnce(spy);
+
+    Event.emit('hello');
+    sinon.assert.calledTwice(spy);
 
     Event.removeAllListeners();
 
-    Event.emit('hello'); // call-2
-    Event.on('hello', spy); // hello listener 1
+    Event.emit('hello');
     sinon.assert.calledTwice(spy);
 
-    Event.emit('hello'); // call-3, call-4
-    Event.on('hello', spy); // hello listener 2
-    sinon.assert.callCount(spy, 4);
+    Event.emit('hello');
+    Event.on('hello', spy);
+    sinon.assert.calledThrice(spy);
 
     done();
+  });
+  it('should remove immediate listeners of the specified event name', function(done) {
+    var spyHello = sinon.spy();
+    var spyGoodbye = sinon.spy();
+
+    Event.emit('hello');
+    Event.emit('goodbye');
+
+    Event.on('hello', spyHello);
+    Event.on('goodbye', spyGoodbye);
+
+    sinon.assert.calledOnce(spyHello);
+    sinon.assert.calledOnce(spyGoodbye);
+
+    Event.emit('hello');
+    Event.emit('goodbye');
+
+    Event.removeAllListeners('hello');
+
+    Event.on('hello', spyHello);
+
+    sinon.assert.calledTwice(spyHello);
+    sinon.assert.calledTwice(spyGoodbye);
+
+    done();
+  });
+  it('should remove a specific listener', function(done) {
+    var spyHello = sinon.spy();
+    var spyGoodbye = sinon.spy();
+    var spyGoodbye2 = sinon.spy();
+
+    Event.on('hello', spyHello);
+    Event.on('goodbye', spyGoodbye);
+    Event.on('goodbye', spyGoodbye2);
+
+    assert.equal(Event.listeners('hello').length, 1, 'should be one hello listener');
+    assert.equal(Event.listeners('goodbye').length, 2, 'should be two goodbye listeners');
+
+    Event.emit('hello', 1);
+    Event.emit('goodbye', 1);
+    sinon.assert.calledOnce(spyHello);
+    sinon.assert.calledOnce(spyGoodbye);
+    sinon.assert.calledOnce(spyGoodbye2);
+
+    Event.removeListener('goodbye', spyGoodbye2);
+
+    assert.equal(Event.listeners('hello').length, 1, 'should be one hello listener');
+    assert.equal(Event.listeners('goodbye').length, 1, 'should be one goodbye listener');
+
+    Event.emit('hello', 1);
+    Event.emit('goodbye', 1);
+
+    sinon.assert.calledTwice(spyHello);
+    sinon.assert.calledTwice(spyGoodbye);
+    sinon.assert.calledOnce(spyGoodbye2);
+
+    done();
+  });
+  it('should observe events emitted before observers registered', function(done) {
+    var spy1 = sinon.spy();
+    var spy2 = sinon.spy();
+    var spy3 = sinon.spy();
+
+    setTimeout(function() {
+      Event.emit('foo');
+    }, 0);
+
+    Event.on('foo', spy1);
+    Event.on('foo', spy2);
+    Event.on('foo', spy3);
+
+    Event.emit('foo');
+
+    Event.on('foo', spy1);
+    Event.on('foo', spy2);
+    Event.on('foo', spy3);
+
+    setTimeout(function(event) {
+      sinon.assert.calledThrice(spy1);
+      sinon.assert.calledThrice(spy2);
+      sinon.assert.calledThrice(spy3);
+      done();
+    }, 0);
+  });
+  it('should observe events emitted async sparsely', function(done) {
+    var spy1 = sinon.spy();
+    var spy2 = sinon.spy();
+    var spy3 = sinon.spy();
+
+    Event.on('foo', spy1);
+
+    setTimeout(function() {
+      Event.emit('foo');
+    }, 0);
+
+    Event.on('foo', spy2);
+
+    setTimeout(function() {
+      Event.emit('foo');
+    }, 0);
+
+    Event.on('foo', spy3);
+
+    setTimeout(function(event) {
+      sinon.assert.calledTwice(spy1);
+      sinon.assert.calledTwice(spy2);
+      sinon.assert.calledTwice(spy3);
+      done();
+    }, 0);
   });
   it('should invoke the done callback', function(done) {
     Event.on('hello', done);
@@ -87,7 +226,7 @@ describe('Event - Tests', function () {
     Event.emit('hello');
     Event.on('hello', done);
   });
-  it.skip('should have event bus behavior', function(done) {
+  it('should have event bus behavior', function(done) {
     var spy = sinon.spy();
     Event.emit('hello', 1);
     Event.on('hello', spy);
@@ -96,25 +235,6 @@ describe('Event - Tests', function () {
       sinon.assert.calledWithExactly(spy.getCall(0), 1);
       sinon.assert.calledWithExactly(spy.getCall(1), 2);
       sinon.assert.calledTwice(spy);
-      done();
-    }, 0);
-  });
-  it.skip('should allow multiple event bus listeners', function(done) {
-    var firstListener = sinon.spy();
-    var secondListener = sinon.spy();
-    Event.emit('hello', 3);
-    Event.on('hello', firstListener);
-    Event.emit('hello', 4);
-    Event.on('hello', secondListener);
-    setTimeout(function() {
-      sinon.assert.calledWithExactly(firstListener.getCall(0), 3);
-      sinon.assert.calledWithExactly(firstListener.getCall(1), 4);
-      sinon.assert.calledWithExactly(secondListener.getCall(0), 3);
-      // sinon.assert.calledWithExactly(secondListener.getCall(1), 4);
-      // NOTE this second event won't hit the second listener
-      // TODO figure out if this even make sense?
-      sinon.assert.calledTwice(firstListener);
-      sinon.assert.calledOnce(secondListener);
       done();
     }, 0);
   });
@@ -130,45 +250,17 @@ describe('Event - Tests', function () {
     Event.on('AUCTION_POST_RUN', thirdListener);
     setTimeout(function() {
       sinon.assert.calledWithExactly(firstListener.getCall(0), 5);
-      sinon.assert.calledWithExactly(secondListener.getCall(0), 5);
-      sinon.assert.calledWithExactly(secondListener.getCall(1), 6);
-      sinon.assert.calledWithExactly(thirdListener.getCall(0), 5);
-      sinon.assert.calledWithExactly(thirdListener.getCall(1), 6);
-      sinon.assert.calledWithExactly(thirdListener.getCall(2), 7);
-      sinon.assert.calledOnce(firstListener);
-      sinon.assert.calledTwice(secondListener);
-      sinon.assert.calledThrice(thirdListener);
-      done();
-    }, 0);
-  });
-  it.skip('should deal carefully with AUCTION_POST_RUN', function(done) {
-    var firstListener = sinon.spy();
-    var secondListener = sinon.spy();
-    var thirdListener = sinon.spy();
-    Event.emit('AUCTION_POST_RUN', 5);
-    Event.on('AUCTION_POST_RUN', firstListener);
-    Event.emit('AUCTION_POST_RUN', 6);
-    Event.on('AUCTION_POST_RUN', secondListener);
-    Event.emit('AUCTION_POST_RUN', 7);
-    Event.on('AUCTION_POST_RUN', thirdListener);
-    setTimeout(function() {
-      sinon.assert.calledWithExactly(firstListener.getCall(0), 5);
       sinon.assert.calledWithExactly(firstListener.getCall(1), 6);
       sinon.assert.calledWithExactly(firstListener.getCall(2), 7);
-      sinon.assert.calledWithExactly(secondListener.getCall(0), 5);
-      sinon.assert.calledWithExactly(secondListener.getCall(1), 6);
-      sinon.assert.calledWithExactly(secondListener.getCall(2), 7);
-      sinon.assert.calledWithExactly(thirdListener.getCall(0), 5);
-      sinon.assert.calledWithExactly(thirdListener.getCall(1), 6);
-      sinon.assert.calledWithExactly(thirdListener.getCall(2), 7);
+      sinon.assert.calledWithExactly(secondListener.getCall(0), 6);
+      sinon.assert.calledWithExactly(secondListener.getCall(1), 7);
+      sinon.assert.calledWithExactly(thirdListener.getCall(0), 7);
       sinon.assert.calledThrice(firstListener);
-      sinon.assert.calledThrice(secondListener);
-      sinon.assert.calledThrice(thirdListener);
+      sinon.assert.calledTwice(secondListener);
+      sinon.assert.calledOnce(thirdListener);
       done();
     }, 0);
   });
-  it.skip('should exercise publish');
-  it.skip('should consider pubfood.observe usage');
   it('should have a default auctionId', function(done) {
     assert.match(Event.auctionId, /^pubfood:[0-9]+/, 'default auctionId should be \"pubfood:<Date.now()>\"');
     done();

--- a/test/event/index.js
+++ b/test/event/index.js
@@ -104,7 +104,7 @@ describe('Event - Tests', function () {
     sinon.assert.calledTwice(spy);
 
     Event.emit('hello');
-    Event.on('hello', spy);
+    Event.on('hello', spy, Event.OBSERVE_TYPE.ONCE);
     sinon.assert.calledThrice(spy);
 
     done();
@@ -185,7 +185,7 @@ describe('Event - Tests', function () {
     Event.on('foo', spy2);
     Event.on('foo', spy3);
 
-    setTimeout(function(event) {
+    setTimeout(function() {
       sinon.assert.calledThrice(spy1);
       sinon.assert.calledThrice(spy2);
       sinon.assert.calledThrice(spy3);
@@ -211,7 +211,7 @@ describe('Event - Tests', function () {
 
     Event.on('foo', spy3);
 
-    setTimeout(function(event) {
+    setTimeout(function() {
       sinon.assert.calledTwice(spy1);
       sinon.assert.calledTwice(spy2);
       sinon.assert.calledTwice(spy3);
@@ -221,6 +221,46 @@ describe('Event - Tests', function () {
   it('should invoke the done callback', function(done) {
     Event.on('hello', done);
     Event.emit('hello');
+  });
+  it('should listen once', function(done) {
+    var spy1 = sinon.spy();
+
+    Event.on('hello', spy1, Event.OBSERVE_TYPE.ONCE);
+    Event.emit('hello');
+    Event.emit('hello');
+    Event.emit('hello');
+    Event.emit('hello');
+    sinon.assert.calledOnce(spy1);
+    done();
+  });
+  it('should listen once on immediate observers', function(done) {
+    var spy1 = sinon.spy();
+
+    Event.emit('hello');
+    Event.on('hello', spy1, Event.OBSERVE_TYPE.ONCE);
+    Event.emit('hello');
+    Event.emit('hello');
+    Event.emit('hello');
+    sinon.assert.calledOnce(spy1);
+    done();
+  });
+  it('should allow listen once and listen many observers', function(done) {
+    var spy1 = sinon.spy();
+    var spy2 = sinon.spy();
+    var spy3 = sinon.spy();
+
+    Event.on('hello', spy2);
+    Event.on('hello', spy3, Event.OBSERVE_TYPE.ALL);
+    Event.emit('hello');
+    Event.on('hello', spy1, Event.OBSERVE_TYPE.ONCE);
+    Event.emit('hello');
+    Event.emit('hello');
+    Event.removeListener('hello', spy3);
+    Event.emit('hello');
+    sinon.assert.calledOnce(spy1);
+    sinon.assert.callCount(spy2, 4);
+    sinon.assert.calledThrice(spy3);
+    done();
   });
   it('should invoke the done callback even if the emit happens first', function(done) {
     Event.emit('hello');
@@ -238,7 +278,7 @@ describe('Event - Tests', function () {
       done();
     }, 0);
   });
-  it('should speak to current AUCTION_POST_RUN behavior', function(done) {
+  it('should default AUCTION_POST_RUN observers to PubfoodEvent.OBSERVE_TYPE.ONCE', function(done) {
     var firstListener = sinon.spy();
     var secondListener = sinon.spy();
     var thirdListener = sinon.spy();
@@ -249,14 +289,12 @@ describe('Event - Tests', function () {
     Event.emit('AUCTION_POST_RUN', 7);
     Event.on('AUCTION_POST_RUN', thirdListener);
     setTimeout(function() {
-      sinon.assert.calledWithExactly(firstListener.getCall(0), 5);
-      sinon.assert.calledWithExactly(firstListener.getCall(1), 6);
-      sinon.assert.calledWithExactly(secondListener.getCall(0), 6);
-      sinon.assert.calledWithExactly(secondListener.getCall(1), 7);
-      sinon.assert.calledWithExactly(thirdListener.getCall(0), 7);
-      sinon.assert.calledTwice(firstListener);
-      sinon.assert.calledTwice(secondListener);
+      sinon.assert.calledOnce(firstListener);
+      sinon.assert.calledOnce(secondListener);
       sinon.assert.calledOnce(thirdListener);
+      sinon.assert.calledWithExactly(firstListener.getCall(0), 5);
+      sinon.assert.calledWithExactly(secondListener.getCall(0), 6);
+      sinon.assert.calledWithExactly(thirdListener.getCall(0), 7);
       done();
     }, 0);
   });

--- a/test/fixture/auctionconfig1.js
+++ b/test/fixture/auctionconfig1.js
@@ -246,7 +246,7 @@ var pubfoodContrib = {
     },
     {
       name: 'carsales',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         done();
       },
@@ -256,7 +256,7 @@ var pubfoodContrib = {
     },
     {
       name: 'walkathon',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         done();
       },

--- a/test/fixture/auctionprovider1.js
+++ b/test/fixture/auctionprovider1.js
@@ -11,7 +11,7 @@ module.exports = {
   valid: [
     {
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, bids, done) {
       },
       refresh: function(slots, targeting, done) {
@@ -24,7 +24,7 @@ module.exports = {
     },
     {
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, bids, done) {
       },
       trigger: function(done) {
@@ -37,7 +37,7 @@ module.exports = {
   invalid: [
     {
       name: 'provider2',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       refresh: function(slots, targeting, done) {
       },
       trigger: function(done) {
@@ -47,7 +47,7 @@ module.exports = {
       }
     },
     {
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, bids, done) {
       },
       refresh: function(slots, targeting, done) {
@@ -71,7 +71,7 @@ module.exports = {
       }
     },
     {
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, bids, done) {
       },
       trigger: function(done) {

--- a/test/mediator/auctionmediator.js
+++ b/test/mediator/auctionmediator.js
@@ -33,7 +33,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     TEST_MEDIATOR.addBidProvider({
       name: 'b1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         pushBid({
           slot: '/abc/123',
@@ -51,7 +51,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     TEST_MEDIATOR.setAuctionProvider({
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -158,7 +158,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     m1.addBidProvider({
       name: 'b2',
-      libUri: 'someUri',
+      libUri: 'http://',
       init: function(slots, pushBid, done) {
 
       },
@@ -187,7 +187,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     var m2provider = m2.addBidProvider({
       name: 'b2',
-      libUri: 'someUri',
+      libUri: 'http://',
       init: function(slots, pushBid, done) {
 
       },
@@ -213,7 +213,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     m2.addBidProvider({
       name: 'b2',
-      libUri: 'someUri',
+      libUri: 'http://',
       init: function(slots, pushBid, done) {
 
       },
@@ -258,7 +258,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
     var m = new AuctionMediator();
     m.addBidProvider({
       name: 'b1',
-      libUri: 'someUri',
+      libUri: 'http://',
       init: function(slots, pushBid, done) {
         done();
       },
@@ -281,7 +281,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     m.setAuctionProvider({
       name: 'p1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -324,7 +324,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
     var m = new AuctionMediator();
     m.setAuctionProvider({
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -360,7 +360,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
     var m = new AuctionMediator();
     m.setAuctionProvider({
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -387,7 +387,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
     var m = new AuctionMediator();
     m.setAuctionProvider({
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -404,7 +404,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     var providerDelegate = {
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -444,7 +444,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     m.addBidProvider({
       name: 'p1',
-      libUri: 'someUri',
+      libUri: 'http://',
       init: function(slots, pushBid, done) {
         done();
       },
@@ -454,7 +454,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
     });
     m.addBidProvider({
       name: 'p2',
-      libUri: 'someUri',
+      libUri: 'http://',
       init: function(slots, pushBid, done) {
         done();
       },
@@ -465,7 +465,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     m.setAuctionProvider({
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -500,7 +500,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     m.addBidProvider({
       name: 'b1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         pushBid({
           slot: '/abc/123',
@@ -517,7 +517,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     m.setAuctionProvider({
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -553,7 +553,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     m.addBidProvider({
       name: 'b1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         pushBid({
           slot: '/abc/123',
@@ -571,7 +571,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     m.setAuctionProvider({
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -632,7 +632,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     m.addBidProvider({
       name: 'b1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         pushBid({
           slot: '/abc/123',
@@ -649,7 +649,7 @@ describe('Pubfood AuctionMediator', function testPubfoodMediator() {
 
     m.setAuctionProvider({
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },

--- a/test/mediator/auctionmediatorlatebids.js
+++ b/test/mediator/auctionmediatorlatebids.js
@@ -38,7 +38,7 @@ describe('Late bids', function () {
 
     m.addBidProvider({
       name: 'b1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         var argPushBid = pushBid;
         setTimeout(function() {
@@ -57,7 +57,7 @@ describe('Late bids', function () {
 
     m.setAuctionProvider({
       name: 'provider1.7',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -93,7 +93,7 @@ describe('Late bids', function () {
 
     m.addBidProvider({
       name: 'b1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         var argPushBid = pushBid;
         setTimeout(function() {
@@ -112,7 +112,7 @@ describe('Late bids', function () {
 
     m.setAuctionProvider({
       name: 'provider1.6',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -148,7 +148,7 @@ describe('Late bids', function () {
 
     m.addBidProvider({
       name: 'b1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         var argPushBid = pushBid;
         setTimeout(function() { // should be late bid
@@ -167,7 +167,7 @@ describe('Late bids', function () {
 
     m.addBidProvider({
       name: 'b2',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         pushBid({              // should be timely bid
           slot: '/abc/123',
@@ -183,7 +183,7 @@ describe('Late bids', function () {
 
     m.setAuctionProvider({
       name: 'provider1.5',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -235,7 +235,7 @@ describe('Late bids', function () {
 
     m.addBidProvider({
       name: 'b1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         setTimeout(function() {
           done();
@@ -248,7 +248,7 @@ describe('Late bids', function () {
 
     m.setAuctionProvider({
       name: 'provider1.4',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -282,7 +282,7 @@ describe('Late bids', function () {
 
     m.addBidProvider({
       name: 'b1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         done();
       },
@@ -293,7 +293,7 @@ describe('Late bids', function () {
 
     m.setAuctionProvider({
       name: 'provider1.3',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         setTimeout(function() {
           done();
@@ -328,7 +328,7 @@ describe('Late bids', function () {
 
     m.addBidProvider({
       name: 'b1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         done();
       },
@@ -339,7 +339,7 @@ describe('Late bids', function () {
 
     m.setAuctionProvider({
       name: 'provider1.2',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         setTimeout(function() {
           done();
@@ -376,7 +376,7 @@ describe('Late bids', function () {
 
     m.addBidProvider({
       name: 'b1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         done();
       },
@@ -387,7 +387,7 @@ describe('Late bids', function () {
 
     m.setAuctionProvider({
       name: 'provider1.1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },

--- a/test/mediator/auctionmediatorrefresh.js
+++ b/test/mediator/auctionmediatorrefresh.js
@@ -31,7 +31,7 @@ describe('Auction Refresh', function () {
 
     TEST_MEDIATOR.addBidProvider({
       name: 'b1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         pushBid({
           slot: '/abc/123',
@@ -54,7 +54,7 @@ describe('Auction Refresh', function () {
 
     TEST_MEDIATOR.setAuctionProvider({
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -82,7 +82,7 @@ describe('Auction Refresh', function () {
   it('should keep track bids per auction', function(done) {
     TEST_MEDIATOR.setAuctionProvider({
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -109,7 +109,7 @@ describe('Auction Refresh', function () {
     // Add another bid provider
     TEST_MEDIATOR.addBidProvider({
       name: 'b2',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         pushBid({
           slot: '/abc/123',
@@ -146,7 +146,7 @@ describe('Auction Refresh', function () {
   it('should allow optional slot names array argument to refresh', function(done) {
     TEST_MEDIATOR.setAuctionProvider({
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         done();
       },
@@ -172,7 +172,7 @@ describe('Auction Refresh', function () {
     // Redefine the auction provider
     TEST_MEDIATOR.setAuctionProvider({
       name: 'provider1',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(targeting, done) {
         auctionTargeting.init.push(targeting);
         done();
@@ -186,7 +186,7 @@ describe('Auction Refresh', function () {
     // Add another bid provider
     TEST_MEDIATOR.addBidProvider({
       name: 'b2',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         pushBid({
           slot: '/abc/123',
@@ -272,7 +272,7 @@ describe('Auction Refresh', function () {
     // Add more bid providers
     TEST_MEDIATOR.addBidProvider({
       name: 'b2',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         var argPushBid = pushBid;
         setTimeout(function() {
@@ -299,7 +299,7 @@ describe('Auction Refresh', function () {
 
     TEST_MEDIATOR.addBidProvider({
       name: 'b3',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         var argPushBid = pushBid;
         setTimeout(function() {
@@ -362,7 +362,7 @@ describe('Auction Refresh', function () {
     // Add more bid providers
     TEST_MEDIATOR.addBidProvider({
       name: 'b2',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         done();
       },
@@ -373,7 +373,7 @@ describe('Auction Refresh', function () {
 
     TEST_MEDIATOR.addBidProvider({
       name: 'b3',
-      libUri: '../test/fixture/lib.js',
+      libUri: 'fixture/lib.js',
       init: function(slots, pushBid, done) {
         done();
       },

--- a/test/unit-test-index.html
+++ b/test/unit-test-index.html
@@ -2,17 +2,18 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <link rel="stylesheet" href="https://cdn.rawgit.com/mochajs/mocha/v2.5.3/mocha.css" />
-        <title>Pubfood Unite Tests</title>
+        <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
+        <title>Pubfood Unit Tests</title>
     </head>
     <body>
 
         <div id="mocha"></div>
 
-        <script src="https://cdn.rawgit.com/mochajs/mocha/v2.5.3/mocha.js"></script>
+        <script src="../node_modules/mocha/mocha.js"></script>
 
         <script type="text/javascript">
          mocha.ui('bdd');
+         mocha.timeout(60000);
         </script>
 
         <script src="../test/unittests.js"></script>

--- a/test/unit-test-index.html
+++ b/test/unit-test-index.html
@@ -13,7 +13,6 @@
 
         <script type="text/javascript">
          mocha.ui('bdd');
-         mocha.timeout(60000);
         </script>
 
         <script src="../test/unittests.js"></script>

--- a/test/unittestindex.js
+++ b/test/unittestindex.js
@@ -12,3 +12,4 @@ require('./mediator');
 require('./model');
 require('./provider');
 require('./util');
+require('./api/index.js');


### PR DESCRIPTION
Fixes #80 

### Additions

- the ability to remove event observers registered with `pubfood.observe()`:
    - `pubfood.removeAllListeners(eventName)`
    - `pubfood.removeAllListeners(eventName, listener)`
- the ability to observe events by `PubfoodEvent.OBSERVE_TYPE`:
    - `ONCE: 1`
    - `ALL: -1`

### Fixes

- References to test fixture noop provider file `lib/fixture/lib.js`
- Test references to an external resource 

***Notes:***
 - Previously in this comment it was suggested that there would be a library function - `pubfood.getEventEmitter()`. However, it has been decided to not include a public API accessor for what should be considered an internal event emitter.